### PR TITLE
Implements batch GPX file import

### DIFF
--- a/my-gpx-activities/my-gpx-activities.ServiceDefaults/Extensions.cs
+++ b/my-gpx-activities/my-gpx-activities.ServiceDefaults/Extensions.cs
@@ -34,8 +34,18 @@ public static class Extensions
 
         builder.Services.ConfigureHttpClientDefaults(http =>
         {
-            // Turn on resilience by default
-            http.AddStandardResilienceHandler();
+            // Turn on resilience by default with custom timeout for file uploads
+            http.AddStandardResilienceHandler(options =>
+            {
+                // Increase timeout for file upload scenarios (2 minutes)
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(2);
+                
+                // Also increase individual attempt timeout
+                options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(2);
+                
+                // Circuit breaker sampling duration must be at least 2x the attempt timeout
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(5);
+            });
 
             // Turn on service discovery by default
             http.AddServiceDiscovery();

--- a/my-gpx-activities/webapp/Components/Pages/Import.razor
+++ b/my-gpx-activities/webapp/Components/Pages/Import.razor
@@ -137,12 +137,31 @@
 
         try
         {
+            // Validate all files before uploading
             foreach (var file in selectedFiles)
             {
-                await UploadFile(file);
+                if (file.Size > 10 * 1024 * 1024)
+                {
+                    throw new Exception($"File {file.Name} is too large. Maximum size is 10MB.");
+                }
+
+                if (!file.Name.EndsWith(".gpx", StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new Exception($"File {file.Name} is not a valid GPX file.");
+                }
             }
 
-            Snackbar.Add($"{selectedFiles.Count} file(s) uploaded successfully", Severity.Success);
+            // Use batch upload for multiple files, single upload for one file
+            if (selectedFiles.Count > 1)
+            {
+                await UploadBatch(selectedFiles);
+            }
+            else
+            {
+                await UploadFile(selectedFiles[0]);
+                Snackbar.Add("File uploaded successfully", Severity.Success);
+            }
+
             selectedFiles = null;
         }
         catch (Exception ex)
@@ -156,99 +175,91 @@
         }
     }
 
-    private async Task UploadFile(IBrowserFile file)
+    private async Task UploadBatch(IReadOnlyList<IBrowserFile> files)
     {
-        try
+        using var client = HttpClientFactory.CreateClient("ApiService");
+        using var content = new MultipartFormDataContent();
+
+        // Read all files into memory first to avoid concurrent SignalR stream issues
+        foreach (var file in files)
         {
-            // Validate file size (10MB limit)
-            if (file.Size > 10 * 1024 * 1024)
-            {
-                throw new Exception($"File {file.Name} is too large. Maximum size is 10MB.");
-            }
-
-            // Validate file extension
-            if (!file.Name.EndsWith(".gpx", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new Exception($"File {file.Name} is not a valid GPX file.");
-            }
-
-            using var client = HttpClientFactory.CreateClient("ApiService");
-            using var content = new MultipartFormDataContent();
-            // OpenReadStream requires maxAllowedSize parameter for files > 512KB
-            using var fileContent = new StreamContent(file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024));
+            // Read the entire file into memory (files are limited to 10MB)
+            using var stream = file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024);
+            using var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+            
+            // Add the file content from memory
+            var fileContent = new ByteArrayContent(memoryStream.ToArray());
             fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
             content.Add(fileContent, "gpx", file.Name);
+        }
 
-            var response = await client.PostAsync("api/activities/import", content);
+        var response = await client.PostAsync("api/activities/import/batch", content);
 
-            if (response.IsSuccessStatusCode)
+        if (response.IsSuccessStatusCode)
+        {
+            var batchResult = await response.Content.ReadFromJsonAsync<BatchUploadResult>();
+            if (batchResult != null)
             {
-                var activity = await response.Content.ReadFromJsonAsync<webapp.Services.ActivitySummary>();
-                if (activity != null)
+                // Add successful activities to the list
+                foreach (var result in batchResult.Results.Where(r => r.Success && r.Activity != null))
                 {
-                    uploadedActivities.Add(activity);
-                    ActivityStore.Add(activity); // Add to shared store
+                    uploadedActivities.Add(result.Activity!);
+                    ActivityStore.Add(result.Activity!);
+                }
+
+                // Show summary message
+                if (batchResult.FailureCount > 0)
+                {
+                    Snackbar.Add($"{batchResult.SuccessCount}/{batchResult.TotalFiles} files uploaded successfully. {batchResult.FailureCount} failed.", Severity.Warning);
+                    
+                    // Show individual error messages
+                    foreach (var result in batchResult.Results.Where(r => !r.Success))
+                    {
+                        Snackbar.Add($"{result.FileName}: {result.ErrorMessage}", Severity.Error);
+                    }
                 }
                 else
                 {
-                    throw new Exception($"Invalid response format for {file.Name}");
+                    Snackbar.Add($"All {batchResult.SuccessCount} files uploaded successfully!", Severity.Success);
                 }
             }
-            else
-            {
-                var errorContent = await response.Content.ReadAsStringAsync();
-                var errorMessage = $"Failed to process {file.Name}";
-
-                if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
-                {
-                    errorMessage += ": Invalid GPX file or format";
-                }
-                else if (response.StatusCode == System.Net.HttpStatusCode.RequestEntityTooLarge)
-                {
-                    errorMessage += ": File too large for server";
-                }
-                else if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError)
-                {
-                    errorMessage += ": Server error processing file";
-                }
-                else
-                {
-                    errorMessage += $": {response.StatusCode}";
-                }
-
-                if (!string.IsNullOrEmpty(errorContent))
-                {
-                    try
-                    {
-                        var problemDetails = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(errorContent);
-                        if (problemDetails.TryGetProperty("detail", out var detail))
-                        {
-                            errorMessage += $" - {detail.GetString()}";
-                        }
-                    }
-                    catch
-                    {
-                        // If we can't parse the error, just use the raw content
-                        errorMessage += $" - {errorContent}";
-                    }
-                }
-
-                throw new Exception(errorMessage);
-            }
         }
-        catch (HttpRequestException ex)
+        else
         {
-            throw new Exception($"Network error uploading {file.Name}: {ex.Message}");
-        }
-        catch (Exception ex) when (ex.Message.Contains("too large") || ex.Message.Contains("size"))
-        {
-            throw; // Re-throw file size errors as-is
-        }
-        catch (Exception ex)
-        {
-            throw new Exception($"Error uploading {file.Name}: {ex.Message}");
+            var errorContent = await response.Content.ReadAsStringAsync();
+            throw new Exception($"Batch upload failed: {errorContent}");
         }
     }
+
+    private async Task UploadFile(IBrowserFile file)
+    {
+        using var client = HttpClientFactory.CreateClient("ApiService");
+        using var content = new MultipartFormDataContent();
+        using var fileContent = new StreamContent(file.OpenReadStream(maxAllowedSize: 10 * 1024 * 1024));
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/octet-stream");
+        content.Add(fileContent, "gpx", file.Name);
+
+        var response = await client.PostAsync("api/activities/import", content);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var activity = await response.Content.ReadFromJsonAsync<webapp.Services.ActivitySummary>();
+            if (activity != null)
+            {
+                uploadedActivities.Add(activity);
+                ActivityStore.Add(activity);
+            }
+        }
+        else
+        {
+            var errorContent = await response.Content.ReadAsStringAsync();
+            throw new Exception($"Upload failed: {errorContent}");
+        }
+    }
+
+    private record BatchUploadResult(int TotalFiles, int SuccessCount, int FailureCount, List<FileUploadResult> Results);
+    private record FileUploadResult(string FileName, bool Success, string? ErrorMessage, webapp.Services.ActivitySummary? Activity);
 
     private string FormatDistance(double meters)
     {

--- a/my-gpx-activities/webapp/Program.cs
+++ b/my-gpx-activities/webapp/Program.cs
@@ -13,7 +13,7 @@ builder.WebHost.ConfigureKestrel(options =>
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
-// Configure HttpClient for API service
+// Configure HttpClient for API service with extended timeout for file uploads
 builder.Services.AddHttpClient("ApiService", (serviceProvider, client) =>
 {
     // Get the API service endpoint from configuration
@@ -23,6 +23,8 @@ builder.Services.AddHttpClient("ApiService", (serviceProvider, client) =>
     {
         client.BaseAddress = new Uri(apiServiceUrl);
     }
+    // Set longer timeout for file uploads (2 minutes)
+    client.Timeout = TimeSpan.FromMinutes(2);
 });
 
 // Add MudBlazor services
@@ -34,6 +36,35 @@ builder.Services.AddSingleton<ActivityStore>();
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
+
+// Configure SignalR for file uploads with extended timeouts
+builder.Services.AddSignalR(options =>
+{
+    // Increase maximum message size for file uploads (100MB to handle multiple files)
+    options.MaximumReceiveMessageSize = 100 * 1024 * 1024;
+    
+    // Disable timeout while streaming file data (set to null for no timeout)
+    options.ClientTimeoutInterval = TimeSpan.FromMinutes(5);
+    
+    // Keep-alive interval
+    options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+    
+    // Handshake timeout
+    options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+});
+
+// Configure Blazor Server Circuit options for file uploads
+builder.Services.AddServerSideBlazor(options =>
+{
+    // Increase the disconnect timeout to prevent disconnection during file uploads
+    options.DisconnectedCircuitRetentionPeriod = TimeSpan.FromMinutes(5);
+    
+    // Allow more time for synchronous JS interop during file reads
+    options.JSInteropDefaultCallTimeout = TimeSpan.FromMinutes(5);
+    
+    // Increase the maximum buffer size for receiving data
+    options.DetailedErrors = builder.Environment.IsDevelopment();
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION
Adds an endpoint to allow users to upload multiple GPX files in a single request, improving the user experience for importing multiple activities.

Increases HTTP client timeout and SignalR message size to handle larger file uploads. Adds client-side validation to ensure files are within acceptable size limits and are valid GPX files.

Includes error handling and feedback for individual file uploads within the batch, providing detailed information on success and failure scenarios.
