### PR TITLE
ci: extend squad-main-guard to block .copilot/ and copilot-instructions.md from main

### DIFF
--- a/.github/workflows/squad-main-guard.yml
+++ b/.github/workflows/squad-main-guard.yml
@@ -1,0 +1,141 @@
+name: Squad Protected Branch Guard
+
+on:
+  pull_request:
+    branches: [main, preview, insider]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, preview, insider]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for forbidden paths
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Fetch all files changed - handles both PR and push events
+            let files = [];
+            
+            if (context.eventName === 'pull_request') {
+              // PR event: use pulls.listFiles API
+              let page = 1;
+              while (true) {
+                const resp = await github.rest.pulls.listFiles({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100,
+                  page
+                });
+                files.push(...resp.data);
+                if (resp.data.length < 100) break;
+                page++;
+              }
+            } else if (context.eventName === 'push') {
+              // Push event: compare against base branch
+              const base = context.payload.before;
+              const head = context.payload.after;
+              
+              // If this is not a force push and base exists, compare commits
+              if (base && base !== '0000000000000000000000000000000000000000') {
+                const comparison = await github.rest.repos.compareCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  base,
+                  head
+                });
+                files = comparison.data.files || [];
+              } else {
+                // Force push or initial commit: list all files in the current tree
+                core.info('Force push detected or initial commit, checking tree state');
+                const { data: tree } = await github.rest.git.getTree({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tree_sha: head,
+                  recursive: 'true'
+                });
+                files = tree.tree
+                  .filter(item => item.type === 'blob')
+                  .map(item => ({ filename: item.path, status: 'added' }));
+              }
+            }
+
+            // Check each file against forbidden path rules
+            // Allow removals ΓÇö deleting forbidden files from protected branches is fine
+            const forbidden = files
+              .filter(f => f.status !== 'removed')
+              .map(f => f.filename)
+              .filter(f => {
+                // .ai-team/** and .squad/** ΓÇö ALL team state files, zero exceptions
+                if (f === '.ai-team' || f.startsWith('.ai-team/') || f === '.squad' || f.startsWith('.squad/')) return true;
+                // .ai-team-templates/** ΓÇö Squad's own templates, stay on dev
+                if (f === '.ai-team-templates' || f.startsWith('.ai-team-templates/')) return true;
+                // team-docs/** ΓÇö ALL internal team docs, zero exceptions
+                if (f.startsWith('team-docs/')) return true;
+                // docs/proposals/** ΓÇö internal design proposals, stay on dev
+                if (f.startsWith('docs/proposals/')) return true;
+                // .copilot/** ΓÇö Copilot config/MCP, stay on dev
+                if (f === '.copilot' || f.startsWith('.copilot/')) return true;
+                // .github/copilot-instructions.md ΓÇö Copilot prompt config, stay on dev
+                if (f === '.github/copilot-instructions.md') return true;
+                return false;
+              });
+
+            if (forbidden.length === 0) {
+              core.info('Γ£à No forbidden paths found in PR ΓÇö all clear.');
+              return;
+            }
+
+            // Build a clear, actionable error message
+            const lines = [
+              '## ≡ƒÜ½ Forbidden files detected in PR to main',
+              '',
+              'The following files must NOT be merged into `main`.',
+              '`.ai-team/` and `.squad/` are runtime team state ΓÇö they belong on dev branches only.',
+              '`.ai-team-templates/` is Squad\'s internal planning ΓÇö it belongs on dev branches only.',
+              '`team-docs/` is internal team content ΓÇö it belongs on dev branches only.',
+              '`docs/proposals/` is internal design proposals ΓÇö it belongs on dev branches only.',
+              '`.copilot/` is Copilot/MCP configuration ΓÇö it belongs on dev branches only.',
+              '`.github/copilot-instructions.md` is the Copilot prompt config ΓÇö it belongs on dev branches only.',
+              '',
+              '### Forbidden files found:',
+              '',
+              ...forbidden.map(f => `- \`${f}\``),
+              '',
+              '### How to fix:',
+              '',
+              '```bash',
+              '# Remove tracked .ai-team/ files (keeps local copies):',
+              'git rm --cached -r .ai-team/',
+              '',
+              '# Remove tracked .squad/ files (keeps local copies):',
+              'git rm --cached -r .squad/',
+              '',
+              '# Remove tracked .copilot/ files (keeps local copies):',
+              'git rm --cached -r .copilot/',
+              '',
+              '# Remove tracked .github/copilot-instructions.md (keeps local copy):',
+              'git rm --cached .github/copilot-instructions.md',
+              '',
+              '# Remove tracked team-docs/ files:',
+              'git rm --cached -r team-docs/',
+              '',
+              '# Commit the removal and push:',
+              'git commit -m "chore: remove forbidden paths from PR"',
+              'git push',
+              '```',
+              '',
+              '> ΓÜá∩╕Å `.ai-team/`, `.squad/`, and `.copilot/` are committed on `dev` and feature branches by design.',
+              '> The guard workflow is the enforcement mechanism that keeps these files off `main` and `preview`.',
+              '> `git rm --cached` untracks them from this PR without deleting your local copies.',
+            ];
+
+            core.setFailed(lines.join('\n'));

--- a/.squad/agents/bobbie/history.md
+++ b/.squad/agents/bobbie/history.md
@@ -1,0 +1,24 @@
+# History — Bobbie
+
+## Project Context
+**Project:** my-gpx-activities — GPS sports activity visualizer
+**Stack:** .NET 10 Aspire, Blazor Server (MudBlazor), ApiService (Minimal API + OpenAPI), PostgreSQL (Npgsql), NUnit tests
+**Repo layout:**
+- my-gpx-activities.ApiService/ — backend API, GPX/FIT parsing, repositories
+- my-gpx-activities.AppHost/ — Aspire orchestration host
+- my-gpx-activities.webapp/ — Blazor Server frontend
+- my-gpx-activities.ServiceDefaults/ — shared extensions
+- my-gpx-activities.Tests/ — NUnit integration tests
+**User:** fboucher
+
+## Learnings
+
+### 2026-02-25: Copilot config files blocked from `main`
+
+Extended `.github/workflows/squad-main-guard.yml` (which already blocked `.squad/`, `.ai-team/`, etc.) to also block `.copilot/` and `.github/copilot-instructions.md`. Creating a new `check-squad-files.yml` was rejected because it would duplicate logic — extending the existing guard was the cleaner solution.
+
+Key learnings:
+- `.gitignore` on `main` is a bad approach because it's branch-specific and conflicts on every `dev` → `main` merge.
+- The `squad-main-guard.yml` workflow uses `f.status !== 'removed'` to allow deletion PRs — so you can clean up forbidden files from `main` via PR without the guard blocking you.
+- The guard fires on both `pull_request` and `push` events to protected branches, including handling force pushes via tree enumeration.
+- Decision documented in `.squad/decisions/inbox/bobbie-main-branch-protection.md`.

--- a/.squad/decisions/inbox/bobbie-main-branch-protection.md
+++ b/.squad/decisions/inbox/bobbie-main-branch-protection.md
@@ -1,0 +1,32 @@
+# Decision: Copilot config files blocked from `main` via existing guard workflow
+
+**Date:** 2026-02-25
+**Author:** Bobbie (DevOps)
+**Status:** Implemented
+
+## Context
+
+The coordinator directive (`coordinator-main-branch-clean.md`) required that `.squad/`, `.copilot/`, and `.github/copilot-instructions.md` be blocked from the `main` branch in an enforceable way that doesn't break the `dev` workflow.
+
+## Decision
+
+Rather than creating a new `check-squad-files.yml` workflow (which would duplicate logic), we extended the **existing** `squad-main-guard.yml` workflow to also block:
+- `.copilot/` — Copilot/MCP configuration (e.g., `mcp-config.json`)
+- `.github/copilot-instructions.md` — the Copilot prompt/instructions file
+
+The existing workflow already covered `.squad/`, `.ai-team/`, `.ai-team-templates/`, `team-docs/`, and `docs/proposals/`. Adding the two Copilot-specific paths keeps enforcement in a single workflow file.
+
+## Why not `.gitignore` on `main`?
+
+Adding `.squad/` to `.gitignore` on `main` would conflict on every merge from `dev` because `.gitignore` is branch-specific. This approach was explicitly rejected in favor of the CI guard.
+
+## Enforcement
+
+- Triggers on `pull_request` targeting `main`, `preview`, and `insider`
+- Also triggers on direct `push` to those branches (guards against force pushes)
+- Fails with a clear, actionable error message listing forbidden files and `git rm --cached` fix instructions
+- Removals (deleting forbidden files) are explicitly allowed — so you can clean up via PR if needed
+
+## Dev workflow impact
+
+None. `.squad/` and `.copilot/` remain fully tracked and committable on `dev` and feature branches. The guard only fires when targeting protected branches.


### PR DESCRIPTION
## What

Extends `.github/workflows/squad-main-guard.yml` to block `.copilot/` and `.github/copilot-instructions.md` from being merged into `main` (and `preview`/`insider`).

## Why

The existing guard already blocked `.squad/`, `.ai-team/`, `team-docs/`, etc. Copilot config files (`.copilot/mcp-config.json`, future `.github/copilot-instructions.md`) are dev-only tooling that should not land in `main`.

## Approach

Rather than creating a new `check-squad-files.yml` (which would duplicate logic), the existing guard was extended. This keeps enforcement in a single place.

## Enforcement

- Triggers on PR and direct push to `main`, `preview`, `insider`
- Fails with a clear, actionable error message + `git rm --cached` fix instructions
- Removals are explicitly allowed (so cleanup PRs are not blocked)

## Files changed

- `.github/workflows/squad-main-guard.yml` — added `.copilot/` and `.github/copilot-instructions.md` to forbidden paths
- `.squad/decisions/inbox/bobbie-main-branch-protection.md` — decision record
- `.squad/agents/bobbie/history.md` — updated Bobbie knowledge