### PR TITLE
feat(webapp): Heat Map page with date/sport filters (#10)

### DIFF
--- a/my-gpx-activities/webapp/Components/Layout/NavMenu.razor
+++ b/my-gpx-activities/webapp/Components/Layout/NavMenu.razor
@@ -3,6 +3,7 @@
     <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
     <MudNavLink Href="activities" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.List">Activities</MudNavLink>
     <MudNavLink Href="statistics" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.BarChart">Statistics</MudNavLink>
+    <MudNavLink Href="heatmap" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Layers">Heat Map</MudNavLink>
     <MudNavLink Href="import" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.CloudUpload">Import GPX</MudNavLink>
 </MudNavMenu>
 

--- a/my-gpx-activities/webapp/Components/Pages/HeatMap.razor
+++ b/my-gpx-activities/webapp/Components/Pages/HeatMap.razor
@@ -1,0 +1,190 @@
+@page "/heatmap"
+@attribute [StreamRendering(true)]
+@implements IAsyncDisposable
+
+@inject webapp.Services.HeatMapApiClient HeatMapClient
+@inject IJSRuntime JSRuntime
+
+<PageTitle>Heat Map</PageTitle>
+
+<MudText Typo="Typo.h3" GutterBottom="true">Heat Map</MudText>
+<MudText Typo="Typo.body1" Color="Color.Secondary" Class="mb-4">
+    View all your GPS activity traces on a single map.
+</MudText>
+
+<MudGrid Class="mb-4">
+    <!-- Date range filters -->
+    <MudItem xs="12" sm="6" md="3">
+        <MudDatePicker Label="From date"
+                       Date="_dateFrom"
+                       DateChanged="d => _dateFrom = d"
+                       DateFormat="yyyy-MM-dd"
+                       Clearable="true"
+                       Variant="Variant.Outlined" />
+    </MudItem>
+    <MudItem xs="12" sm="6" md="3">
+        <MudDatePicker Label="To date"
+                       Date="_dateTo"
+                       DateChanged="d => _dateTo = d"
+                       DateFormat="yyyy-MM-dd"
+                       Clearable="true"
+                       Variant="Variant.Outlined" />
+    </MudItem>
+
+    <!-- Sport type checkboxes -->
+    <MudItem xs="12" md="4">
+        <MudPaper Class="pa-3" Elevation="1">
+            <MudText Typo="Typo.subtitle2" Class="mb-2">Sport Types</MudText>
+            @if (_sportTypes.Count == 0)
+            {
+                <MudText Typo="Typo.caption" Color="Color.Secondary">No sport types found</MudText>
+            }
+            else
+            {
+                <MudStack Spacing="0">
+                    @foreach (var sport in _sportTypes)
+                    {
+                        var s = sport;
+                        <MudCheckBox T="bool"
+                                     Value="@_selectedSports.Contains(s)"
+                                     ValueChanged="@((bool v) => ToggleSport(s, v))"
+                                     Label="@s"
+                                     Color="Color.Primary"
+                                     Dense="true" />
+                    }
+                </MudStack>
+            }
+        </MudPaper>
+    </MudItem>
+
+    <!-- Apply button -->
+    <MudItem xs="12" md="2" Class="d-flex align-end">
+        <MudButton Variant="Variant.Filled"
+                   Color="Color.Primary"
+                   StartIcon="@Icons.Material.Filled.Map"
+                   OnClick="ApplyFilters"
+                   Disabled="@_loading"
+                   FullWidth="true">
+            @if (_loading)
+            {
+                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                <span>Loading...</span>
+            }
+            else
+            {
+                <span>Apply Filters</span>
+            }
+        </MudButton>
+    </MudItem>
+</MudGrid>
+
+@if (!string.IsNullOrEmpty(_errorMessage))
+{
+    <MudAlert Severity="Severity.Error" Class="mb-4">@_errorMessage</MudAlert>
+}
+
+<MudCard>
+    <MudCardContent Class="pa-0">
+        <div id="heatmap" style="height: 600px; width: 100%; border-radius: 4px;"></div>
+    </MudCardContent>
+</MudCard>
+
+@if (_activities.Count > 0)
+{
+    <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
+        Showing @_activities.Count activit@(_activities.Count == 1 ? "y" : "ies")
+    </MudText>
+}
+
+@code {
+    private List<webapp.Services.HeatMapTrackActivity> _activities = [];
+    private List<string> _sportTypes = [];
+    private HashSet<string> _selectedSports = [];
+    private DateTime? _dateFrom;
+    private DateTime? _dateTo;
+    private bool _loading = false;
+    private string? _errorMessage;
+    private bool _mapInitialized = false;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _sportTypes = await HeatMapClient.GetSportTypesAsync();
+            _selectedSports = [.. _sportTypes];
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"Failed to load sport types: {ex.Message}";
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JSRuntime.InvokeVoidAsync("initializeHeatMap", "heatmap");
+            _mapInitialized = true;
+            await LoadAndDrawActivities();
+        }
+    }
+
+    private void ToggleSport(string sport, bool selected)
+    {
+        if (selected) _selectedSports.Add(sport);
+        else _selectedSports.Remove(sport);
+    }
+
+    private async Task ApplyFilters()
+    {
+        await LoadAndDrawActivities();
+    }
+
+    private async Task LoadAndDrawActivities()
+    {
+        if (!_mapInitialized) return;
+
+        _loading = true;
+        _errorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            var from = _dateFrom.HasValue ? DateOnly.FromDateTime(_dateFrom.Value) : (DateOnly?)null;
+            var to = _dateTo.HasValue ? DateOnly.FromDateTime(_dateTo.Value) : (DateOnly?)null;
+            var sports = _selectedSports.Count > 0 ? _selectedSports : null;
+
+            _activities = await HeatMapClient.GetHeatMapActivitiesAsync(from, to, sports);
+
+            var payload = _activities.Select(a => new
+            {
+                activityName = a.ActivityName,
+                sportType = a.SportType,
+                trackPoints = a.TrackPoints
+            }).ToArray();
+
+            await JSRuntime.InvokeVoidAsync("drawHeatMapTraces", (object)payload);
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"Failed to load activities: {ex.Message}";
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("destroyHeatMap");
+        }
+        catch
+        {
+            // Ignore JS errors during disposal
+        }
+    }
+}

--- a/my-gpx-activities/webapp/Program.cs
+++ b/my-gpx-activities/webapp/Program.cs
@@ -32,6 +32,7 @@ builder.Services.AddMudServices();
 
 // Add activity store (in-memory for now, will be replaced with database)
 builder.Services.AddSingleton<ActivityStore>();
+builder.Services.AddTransient<HeatMapApiClient>();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()

--- a/my-gpx-activities/webapp/Services/HeatMapApiClient.cs
+++ b/my-gpx-activities/webapp/Services/HeatMapApiClient.cs
@@ -1,0 +1,50 @@
+using System.Net.Http.Json;
+
+namespace webapp.Services;
+
+public record HeatMapTrackActivity(
+    Guid ActivityId,
+    string ActivityName,
+    string SportType,
+    double[][] TrackPoints);
+
+public class HeatMapApiClient(IHttpClientFactory httpClientFactory)
+{
+    private readonly HttpClient _client = httpClientFactory.CreateClient("ApiService");
+
+    public async Task<List<HeatMapTrackActivity>> GetHeatMapActivitiesAsync(
+        DateOnly? dateFrom,
+        DateOnly? dateTo,
+        IEnumerable<string>? sportTypes,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new List<string>();
+        if (dateFrom.HasValue)
+            query.Add($"dateFrom={dateFrom.Value:yyyy-MM-dd}");
+        if (dateTo.HasValue)
+            query.Add($"dateTo={dateTo.Value:yyyy-MM-dd}");
+        if (sportTypes != null)
+        {
+            var types = string.Join(",", sportTypes);
+            if (!string.IsNullOrWhiteSpace(types))
+                query.Add($"sportTypes={Uri.EscapeDataString(types)}");
+        }
+
+        var url = "/api/activities/heatmap" + (query.Count > 0 ? "?" + string.Join("&", query) : "");
+        var result = await _client.GetFromJsonAsync<List<HeatMapTrackActivity>>(url, cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<List<string>> GetSportTypesAsync(CancellationToken cancellationToken = default)
+    {
+        var activities = await _client.GetFromJsonAsync<List<ActivitySummaryDto>>("/api/activities", cancellationToken);
+        return activities?
+            .Select(a => a.ActivityType)
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .Distinct()
+            .Order()
+            .ToList() ?? [];
+    }
+
+    private record ActivitySummaryDto(string ActivityType);
+}

--- a/my-gpx-activities/webapp/wwwroot/map.js
+++ b/my-gpx-activities/webapp/wwwroot/map.js
@@ -112,3 +112,76 @@ window.destroyMap = () => {
         endMarker = null;
     }
 };
+
+// ── Heat Map ─────────────────────────────────────────────────────────────────
+let heatMap = null;
+let heatMapLayers = [];
+
+const sportColors = [
+    '#E53935', '#8E24AA', '#1E88E5', '#00ACC1',
+    '#43A047', '#FB8C00', '#F4511E', '#6D4C41',
+    '#546E7A', '#D81B60'
+];
+
+function heatMapSportColor(sportType, colorMap) {
+    if (colorMap[sportType]) return colorMap[sportType];
+    const keys = Object.keys(colorMap);
+    const color = sportColors[keys.length % sportColors.length];
+    colorMap[sportType] = color;
+    return color;
+}
+
+window.initializeHeatMap = (elementId) => {
+    if (heatMap) {
+        heatMap.remove();
+        heatMap = null;
+        heatMapLayers = [];
+    }
+    heatMap = L.map(elementId).setView([45.0, -73.0], 6);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(heatMap);
+    setTimeout(() => heatMap.invalidateSize(), 100);
+};
+
+window.drawHeatMapTraces = (activities) => {
+    if (!heatMap) return;
+
+    heatMapLayers.forEach(l => heatMap.removeLayer(l));
+    heatMapLayers = [];
+
+    if (!activities || activities.length === 0) return;
+
+    const colorMap = {};
+    const bounds = L.latLngBounds([]);
+
+    activities.forEach(activity => {
+        const pts = activity.trackPoints;
+        if (!pts || pts.length < 2) return;
+
+        const color = heatMapSportColor(activity.sportType, colorMap);
+        const latlngs = pts.map(p => [p[0], p[1]]);
+
+        const polyline = L.polyline(latlngs, {
+            color,
+            weight: 2,
+            opacity: 0.7
+        }).bindTooltip(`${activity.activityName} (${activity.sportType})`, { sticky: true });
+
+        polyline.addTo(heatMap);
+        heatMapLayers.push(polyline);
+        bounds.extend(latlngs);
+    });
+
+    if (bounds.isValid()) {
+        heatMap.fitBounds(bounds, { padding: [20, 20] });
+    }
+};
+
+window.destroyHeatMap = () => {
+    if (heatMap) {
+        heatMap.remove();
+        heatMap = null;
+        heatMapLayers = [];
+    }
+};


### PR DESCRIPTION
## Summary
Implements the Heat Map page for issue #10.

## Changes
- **New page** `Components/Pages/HeatMap.razor` at route `/heatmap`
  - Interactive Leaflet.js map showing all activity GPS traces as colored polylines
  - Each sport type gets a distinct color
  - Hovering a trace shows activity name and sport type tooltip
- **Date range filter** — MudDatePicker from/to pickers
- **Sport type checkboxes** — toggling individual sports shows/hides their traces
- **Apply Filters button** — re-fetches from API and redraws the map
- **New service** `Services/HeatMapApiClient.cs` — calls `GET /api/activities/heatmap` with filter params; also fetches available sport types from `GET /api/activities`
- **map.js** — appended `initializeHeatMap`, `drawHeatMapTraces`, `destroyHeatMap` JS functions (Leaflet.js already present in App.razor)
- **NavMenu.razor** — added Heat Map link with Layers icon
- **Program.cs** — registered `HeatMapApiClient` as transient service

## Notes
The API endpoint `GET /api/activities/heatmap` was already implemented by the backend team.

Closes #10