### PR TITLE
feat(api): Heat Map backend endpoint (#10)

### DIFF
--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
@@ -203,7 +203,50 @@ public class ActivityRepository : IActivityRepository
         ));
     }
 
-    private static Activity MapToActivity(ActivityDto dto)
+    public async Task<IEnumerable<HeatMapActivity>> GetActivitiesForHeatMapAsync(DateOnly? from, DateOnly? to, string[]? sportTypes)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+
+        var conditions = new List<string>();
+        if (from.HasValue)
+            conditions.Add("start_date_time >= @From");
+        if (to.HasValue)
+            conditions.Add("start_date_time < @To");
+        if (sportTypes is { Length: > 0 })
+            conditions.Add("activity_type = ANY(@SportTypes)");
+
+        var where = conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : string.Empty;
+
+        var sql = $"""
+            SELECT
+                id,
+                title,
+                activity_type,
+                track_coordinates_json
+            FROM activities
+            {where}
+            ORDER BY start_date_time DESC
+            """;
+
+        var rows = await connection.QueryAsync<HeatMapDto>(sql, new
+        {
+            From = from.HasValue ? from.Value.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) : (DateTime?)null,
+            To = to.HasValue ? to.Value.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) : (DateTime?)null,
+            SportTypes = sportTypes
+        });
+
+        return rows.Select(dto => new HeatMapActivity
+        {
+            ActivityId = dto.Id,
+            ActivityName = dto.Title,
+            SportType = dto.Activity_Type,
+            TrackPoints = string.IsNullOrEmpty(dto.Track_Coordinates_Json)
+                ? []
+                : System.Text.Json.JsonSerializer.Deserialize<double[][]>(dto.Track_Coordinates_Json) ?? []
+        });
+    }
+
+        private static Activity MapToActivity(ActivityDto dto)
     {
         return new Activity
         {
@@ -221,6 +264,14 @@ public class ActivityRepository : IActivityRepository
             TrackCoordinatesJson = dto.Track_Coordinates_Json,
             CreatedAt = dto.Created_At
         };
+    }
+
+    private class HeatMapDto
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Activity_Type { get; set; } = string.Empty;
+        public string? Track_Coordinates_Json { get; set; }
     }
 
     // DTO class to handle PostgreSQL snake_case column names

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
@@ -10,6 +10,7 @@ public interface IActivityRepository
     Task<bool> UpdateActivityAsync(Activity activity);
     Task<bool> DeleteActivityAsync(Guid id);
     Task<IEnumerable<SportStatistics>> GetStatisticsBySportAsync();
+    Task<IEnumerable<HeatMapActivity>> GetActivitiesForHeatMapAsync(DateOnly? from, DateOnly? to, string[]? sportTypes);
 }
 
 public interface IActivityTypeRepository

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/HeatMapActivity.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/HeatMapActivity.cs
@@ -1,0 +1,11 @@
+namespace my_gpx_activities.ApiService.Models;
+
+public class HeatMapActivity
+{
+    public Guid ActivityId { get; set; }
+    public string ActivityName { get; set; } = string.Empty;
+    public string SportType { get; set; } = string.Empty;
+
+    // Array of [lat, lon] pairs — optimized for map rendering
+    public double[][] TrackPoints { get; set; } = [];
+}

--- a/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
@@ -292,6 +292,22 @@ app.MapGet("/api/statistics/by-sport", async (IActivityRepository repository) =>
 .WithName("GetStatisticsBySport")
 .WithDescription("Get aggregated statistics grouped by sport type");
 
+app.MapGet("/api/activities/heatmap", async (
+    IActivityRepository repository,
+    DateOnly? dateFrom,
+    DateOnly? dateTo,
+    string? sportTypes) =>
+{
+    string[]? sportTypesArray = string.IsNullOrWhiteSpace(sportTypes)
+        ? null
+        : sportTypes.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    var activities = await repository.GetActivitiesForHeatMapAsync(dateFrom, dateTo, sportTypesArray);
+    return Results.Ok(activities);
+})
+.WithName("GetHeatMapActivities")
+.WithDescription("Get GPS track points for all activities, optionally filtered by date range and sport types, for heat map rendering");
+
 app.MapDefaultEndpoints();
 
 await app.RunAsync();


### PR DESCRIPTION
## Summary
Implements the backend API endpoint for the Heat Map feature (Issue #10).

## Changes
- **New model** `HeatMapActivity`: `ActivityId`, `ActivityName`, `SportType`, `TrackPoints` (array of `[lat, lon]` pairs)
- **New interface method** `IActivityRepository.GetActivitiesForHeatMapAsync(DateOnly? from, DateOnly? to, string[]? sportTypes)`
- **Repository implementation** in `ActivityRepository` with dynamic SQL filtering
- **New endpoint** `GET /api/activities/heatmap` in `Program.cs`

## Endpoint
```
GET /api/activities/heatmap?dateFrom=2024-01-01&dateTo=2024-12-31&sportTypes=Running,Cycling
```

### Query Parameters
| Param | Type | Description |
|-------|------|-------------|
| `dateFrom` | `DateOnly` (optional) | Filter activities starting on or after this date |
| `dateTo` | `DateOnly` (optional) | Filter activities starting before the day after this date |
| `sportTypes` | `string` (optional) | Comma-separated list of activity type names to include |

### Response
```json
[
  {
    "activityId": "guid",
    "activityName": "Morning Run",
    "sportType": "Running",
    "trackPoints": [[45.5017, -73.5673], [45.5020, -73.5680]]
  }
]
```

Closes #10 (backend part)