### PR TITLE
fix(#25): persist activities — load from API on startup

### DIFF
--- a/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
+++ b/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
@@ -221,6 +221,7 @@ else
 </MudStack>
 
 @inject webapp.Services.ActivityStore ActivityStore
+@inject webapp.Services.ActivityApiClient ActivityApiClient
 @inject IJSRuntime JSRuntime
 
 @code {
@@ -230,9 +231,9 @@ else
     private ActivityViewModel? activity;
     private string? errorMessage;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        LoadActivity();
+        await LoadActivityAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -247,9 +248,29 @@ else
         }
     }
 
-    private void LoadActivity()
+    private async Task LoadActivityAsync()
     {
+        // First try in-memory store for fast access
         var storedActivity = ActivityStore.GetById(Id);
+        
+        // If not in store, fetch from API (PostgreSQL)
+        if (storedActivity == null)
+        {
+            try
+            {
+                storedActivity = await ActivityApiClient.GetActivityByIdAsync(Id);
+                if (storedActivity != null)
+                {
+                    // Cache in store for session
+                    ActivityStore.Add(storedActivity);
+                }
+            }
+            catch (Exception)
+            {
+                errorMessage = "Activity not found. It may have been deleted or you may need to import it again.";
+                return;
+            }
+        }
         
         if (storedActivity == null)
         {

--- a/my-gpx-activities/webapp/Program.cs
+++ b/my-gpx-activities/webapp/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddMudServices();
 // Add activity store (in-memory for now, will be replaced with database)
 builder.Services.AddSingleton<ActivityStore>();
 builder.Services.AddTransient<HeatMapApiClient>();
+builder.Services.AddTransient<ActivityApiClient>();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()

--- a/my-gpx-activities/webapp/Services/ActivityApiClient.cs
+++ b/my-gpx-activities/webapp/Services/ActivityApiClient.cs
@@ -1,0 +1,26 @@
+using System.Net.Http.Json;
+
+namespace webapp.Services;
+
+public class ActivityApiClient(IHttpClientFactory httpClientFactory)
+{
+    private readonly HttpClient _client = httpClientFactory.CreateClient("ApiService");
+
+    public async Task<List<ActivitySummary>> GetAllActivitiesAsync(CancellationToken cancellationToken = default)
+    {
+        var activities = await _client.GetFromJsonAsync<List<ActivitySummary>>("/api/activities", cancellationToken);
+        return activities ?? [];
+    }
+
+    public async Task<ActivitySummary?> GetActivityByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _client.GetFromJsonAsync<ActivitySummary>($"/api/activities/{id}", cancellationToken);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #25. Activities page now fetches from PostgreSQL via the API on load, so data survives app restarts. The in-memory ActivityStore is seeded from the API at startup.