### PR TITLE
feat(#24): edit activity name and sport type

### DIFF
--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
@@ -163,6 +163,26 @@ public class ActivityRepository : IActivityRepository
         return rowsAffected > 0;
     }
 
+    public async Task<Activity?> UpdateActivityPartialAsync(Guid id, string? title, string? activityType)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+
+        var existing = await GetActivityByIdAsync(id);
+        if (existing == null) return null;
+
+        if (title != null) existing.Title = title;
+        if (activityType != null) existing.ActivityType = activityType;
+
+        await connection.ExecuteAsync("""
+            UPDATE activities SET
+                title = @Title,
+                activity_type = @ActivityType
+            WHERE id = @Id
+            """, new { existing.Id, existing.Title, existing.ActivityType });
+
+        return existing;
+    }
+
     public async Task<bool> DeleteActivityAsync(Guid id)
     {
         await using var connection = await _connectionFactory.CreateConnectionAsync();

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
@@ -8,6 +8,7 @@ public interface IActivityRepository
     Task<Activity?> GetActivityByIdAsync(Guid id);
     Task<Guid> CreateActivityAsync(Activity activity);
     Task<bool> UpdateActivityAsync(Activity activity);
+    Task<Activity?> UpdateActivityPartialAsync(Guid id, string? title, string? activityType);
     Task<bool> DeleteActivityAsync(Guid id);
     Task<IEnumerable<SportStatistics>> GetStatisticsBySportAsync();
     Task<IEnumerable<HeatMapActivity>> GetActivitiesForHeatMapAsync(DateOnly? from, DateOnly? to, string[]? sportTypes);

--- a/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
@@ -448,6 +448,42 @@ app.MapGet("/api/activities/{id}", async (Guid id, IActivityRepository repositor
 })
 .WithName("GetActivity");
 
+app.MapPatch("/api/activities/{id}", async (Guid id, UpdateActivityRequest request, IActivityRepository repository) =>
+{
+    var updated = await repository.UpdateActivityPartialAsync(id, request.Title, request.ActivityType);
+    if (updated == null) return Results.NotFound();
+
+    List<double[]>? trackCoordinates = null;
+    if (!string.IsNullOrEmpty(updated.TrackCoordinatesJson))
+        trackCoordinates = JsonSerializer.Deserialize<List<double[]>>(updated.TrackCoordinatesJson);
+
+    List<double?[]>? trackData = null;
+    if (!string.IsNullOrEmpty(updated.TrackDataJson))
+        trackData = JsonSerializer.Deserialize<List<double?[]>>(updated.TrackDataJson);
+
+    var response = new
+    {
+        updated.Id,
+        updated.Title,
+        updated.StartDateTime,
+        updated.EndDateTime,
+        updated.ActivityType,
+        updated.DistanceMeters,
+        updated.ElevationGainMeters,
+        updated.ElevationLossMeters,
+        updated.AverageSpeedMs,
+        updated.MaxSpeedMs,
+        TrackPoints = updated.TrackPointCount,
+        updated.CreatedAt,
+        TrackCoordinates = trackCoordinates,
+        TrackData = trackData
+    };
+
+    return Results.Ok(response);
+})
+.WithName("PatchActivity")
+.WithDescription("Partially update an activity's title and/or sport type");
+
 app.MapDelete("/api/activities/{id}", async (Guid id, IActivityRepository repository) =>
 {
     var deleted = await repository.DeleteActivityAsync(id);
@@ -482,3 +518,5 @@ app.MapGet("/api/activities/heatmap", async (
 app.MapDefaultEndpoints();
 
 await app.RunAsync();
+
+public record UpdateActivityRequest(string? Title, string? ActivityType);

--- a/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
+++ b/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
@@ -19,7 +19,14 @@ else if (!string.IsNullOrEmpty(errorMessage))
 }
 else
 {
-    <MudText Typo="Typo.h3" GutterBottom="true">@activity.Title</MudText>
+    <MudStack Row="true" AlignItems="AlignItems.Center" Class="mb-2">
+        <MudText Typo="Typo.h3">@activity.Title</MudText>
+        <MudIconButton Icon="@Icons.Material.Filled.Edit"
+                       Size="Size.Medium"
+                       Color="Color.Primary"
+                       aria-label="Edit activity"
+                       OnClick="OpenEditDialog" />
+    </MudStack>
 
     <MudGrid Class="mb-4">
         <MudItem xs="12" sm="6" md="3">
@@ -189,7 +196,8 @@ else
                         <MudButton Variant="Variant.Outlined"
                                   Color="Color.Secondary"
                                   StartIcon="@Icons.Material.Filled.Edit"
-                                  FullWidth="true">
+                                  FullWidth="true"
+                                  OnClick="OpenEditDialog">
                             Edit Activity
                         </MudButton>
                         <MudButton Variant="Variant.Outlined"
@@ -223,6 +231,7 @@ else
 @inject webapp.Services.ActivityStore ActivityStore
 @inject webapp.Services.ActivityApiClient ActivityApiClient
 @inject IJSRuntime JSRuntime
+@inject MudBlazor.IDialogService DialogService
 
 @code {
     [Parameter]
@@ -230,6 +239,36 @@ else
 
     private ActivityViewModel? activity;
     private string? errorMessage;
+
+    private async Task OpenEditDialog()
+    {
+        if (activity == null) return;
+
+        var activityTypes = await ActivityApiClient.GetActivityTypesAsync();
+
+        var parameters = new MudBlazor.DialogParameters
+        {
+            [nameof(EditActivityDialog.ActivityId)] = activity.Id,
+            [nameof(EditActivityDialog.CurrentTitle)] = activity.Title,
+            [nameof(EditActivityDialog.CurrentActivityType)] = activity.ActivityType,
+            [nameof(EditActivityDialog.ActivityTypes)] = activityTypes
+        };
+
+        var dialog = await DialogService.ShowAsync<EditActivityDialog>("Edit Activity", parameters);
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false, Data: EditActivityResult editResult })
+        {
+            var updated = await ActivityApiClient.UpdateActivityAsync(activity.Id, editResult.Title, editResult.ActivityType);
+            if (updated != null)
+            {
+                ActivityStore.Update(activity.Id, editResult.Title, editResult.ActivityType);
+                activity.Title = updated.Title;
+                activity.ActivityType = updated.ActivityType;
+                StateHasChanged();
+            }
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/my-gpx-activities/webapp/Components/Pages/EditActivityDialog.razor
+++ b/my-gpx-activities/webapp/Components/Pages/EditActivityDialog.razor
@@ -1,0 +1,85 @@
+@using webapp.Services
+@using MudBlazor
+@using static webapp.Services.ActivityApiClient
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="3">
+            <MudTextField @bind-Value="editedTitle" 
+                         Label="Activity Name" 
+                         Variant="Variant.Outlined"
+                         FullWidth="true"
+                         MaxLength="200" />
+            
+            <MudSelect @bind-Value="editedActivityType" 
+                      Label="Sport Type" 
+                      Variant="Variant.Outlined"
+                      FullWidth="true">
+                @foreach (var type in ActivityTypes)
+                {
+                    <MudSelectItem Value="@type.Name">
+                        @if (!string.IsNullOrEmpty(type.Icon))
+                        {
+                            <MudIcon Icon="@type.Icon" Size="Size.Small" Class="mr-2" />
+                        }
+                        @type.Name
+                    </MudSelectItem>
+                }
+            </MudSelect>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" OnClick="Save">Save</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] 
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Parameter] 
+    public Guid ActivityId { get; set; }
+
+    [Parameter] 
+    public string CurrentTitle { get; set; } = string.Empty;
+
+    [Parameter] 
+    public string CurrentActivityType { get; set; } = string.Empty;
+
+    [Parameter] 
+    public List<ActivityTypeDto> ActivityTypes { get; set; } = new();
+
+    private string editedTitle = string.Empty;
+    private string editedActivityType = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        editedTitle = CurrentTitle;
+        editedActivityType = CurrentActivityType;
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+
+    private void Save()
+    {
+        var hasChanges = editedTitle != CurrentTitle || editedActivityType != CurrentActivityType;
+        
+        if (!hasChanges)
+        {
+            MudDialog.Cancel();
+            return;
+        }
+
+        var result = new EditActivityResult(
+            editedTitle != CurrentTitle ? editedTitle : null,
+            editedActivityType != CurrentActivityType ? editedActivityType : null
+        );
+
+        MudDialog.Close(DialogResult.Ok(result));
+    }
+}
+

--- a/my-gpx-activities/webapp/Services/ActivityApiClient.cs
+++ b/my-gpx-activities/webapp/Services/ActivityApiClient.cs
@@ -6,6 +6,10 @@ public class ActivityApiClient(IHttpClientFactory httpClientFactory)
 {
     private readonly HttpClient _client = httpClientFactory.CreateClient("ApiService");
 
+    public record ActivityTypeDto(string Name, string Icon);
+
+    private record UpdateActivityRequest(string? Title, string? ActivityType);
+
     public async Task<List<ActivitySummary>> GetAllActivitiesAsync(CancellationToken cancellationToken = default)
     {
         var activities = await _client.GetFromJsonAsync<List<ActivitySummary>>("/api/activities", cancellationToken);
@@ -22,5 +26,19 @@ public class ActivityApiClient(IHttpClientFactory httpClientFactory)
         {
             return null;
         }
+    }
+
+    public async Task<List<ActivityTypeDto>> GetActivityTypesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await _client.GetFromJsonAsync<List<ActivityTypeDto>>("/api/activity-types", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<ActivitySummary?> UpdateActivityAsync(Guid id, string? title, string? activityType, CancellationToken cancellationToken = default)
+    {
+        var request = new UpdateActivityRequest(title, activityType);
+        var response = await _client.PatchAsJsonAsync($"/api/activities/{id}", request, cancellationToken);
+        if (!response.IsSuccessStatusCode) return null;
+        return await response.Content.ReadFromJsonAsync<ActivitySummary>(cancellationToken);
     }
 }

--- a/my-gpx-activities/webapp/Services/ActivityStore.cs
+++ b/my-gpx-activities/webapp/Services/ActivityStore.cs
@@ -16,6 +16,18 @@ public class ActivityStore
         return _activities.FirstOrDefault(a => a.Id == id);
     }
 
+    public void Update(Guid id, string? title, string? activityType)
+    {
+        var activity = GetById(id);
+        if (activity != null)
+        {
+            if (title != null)
+                activity.Title = title;
+            if (activityType != null)
+                activity.ActivityType = activityType;
+        }
+    }
+
     public void Clear()
     {
         _activities.Clear();

--- a/my-gpx-activities/webapp/Services/EditActivityResult.cs
+++ b/my-gpx-activities/webapp/Services/EditActivityResult.cs
@@ -1,0 +1,3 @@
+namespace webapp.Services;
+
+public record EditActivityResult(string? Title, string? ActivityType);


### PR DESCRIPTION
Closes #24. Adds ability to edit the activity title and sport type from the activity detail page via a dialog.