### PR TITLE
feat(#32): container setup — Docker Hub publish + beta tagging

### DIFF
--- a/.github/workflows/docker-beta.yml
+++ b/.github/workflows/docker-beta.yml
@@ -1,0 +1,52 @@
+name: Docker Publish — Beta (dev)
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute beta version
+        id: version
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          VERSION="${LATEST_TAG#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          NEW_PATCH=$((PATCH + 1))
+          BETA_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}-beta"
+          echo "beta_version=${BETA_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API beta image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./my-gpx-activities
+          file: ./my-gpx-activities/my-gpx-activities.ApiService/Dockerfile
+          push: true
+          tags: fboucher/my-gpx-activities-api:${{ steps.version.outputs.beta_version }}
+
+      - name: Build and push webapp beta image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./my-gpx-activities
+          file: ./my-gpx-activities/webapp/Dockerfile
+          push: true
+          tags: fboucher/my-gpx-activities-webapp:${{ steps.version.outputs.beta_version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Docker Publish — Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./my-gpx-activities
+          file: ./my-gpx-activities/my-gpx-activities.ApiService/Dockerfile
+          push: true
+          tags: |
+            fboucher/my-gpx-activities-api:latest
+            fboucher/my-gpx-activities-api:${{ steps.version.outputs.version }}
+
+      - name: Build and push webapp image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./my-gpx-activities
+          file: ./my-gpx-activities/webapp/Dockerfile
+          push: true
+          tags: |
+            fboucher/my-gpx-activities-webapp:latest
+            fboucher/my-gpx-activities-webapp:${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -24,3 +24,59 @@ The application will be available at:
 - View activity details and analytics
 - Interactive maps showing routes
 - Database persistence with PostgreSQL
+
+## Docker Compose
+
+Pre-built images are published to Docker Hub on every release. Use the example below to run the full stack without a local .NET install.
+
+```yaml
+# docker-compose.yml
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: gpxactivities
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - gpxdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    image: fboucher/my-gpx-activities-api:latest
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__gpxactivities: "Host=db;Database=gpxactivities;Username=postgres;Password=postgres"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  webapp:
+    image: fboucher/my-gpx-activities-webapp:latest
+    ports:
+      - "8081:8080"
+    environment:
+      ASPNETCORE_URLS: http://+:8080
+      services__apiservice__http__0: http://api:8080
+    depends_on:
+      - api
+
+volumes:
+  gpxdata:
+```
+
+Then run:
+
+```bash
+docker compose up
+```
+
+The web UI will be available at **http://localhost:8081** and the API at **http://localhost:8080**.
+
+Replace `latest` with a specific version tag (e.g., `0.2.0`) for reproducible deployments.

--- a/my-gpx-activities/my-gpx-activities.ApiService/Dockerfile
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY ["my-gpx-activities.ApiService/my-gpx-activities.ApiService.csproj", "my-gpx-activities.ApiService/"]
+COPY ["my-gpx-activities.ServiceDefaults/my-gpx-activities.ServiceDefaults.csproj", "my-gpx-activities.ServiceDefaults/"]
+RUN dotnet restore "my-gpx-activities.ApiService/my-gpx-activities.ApiService.csproj"
+COPY . .
+WORKDIR "/src/my-gpx-activities.ApiService"
+RUN dotnet publish "my-gpx-activities.ApiService.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "my-gpx-activities.ApiService.dll"]

--- a/my-gpx-activities/webapp/Dockerfile
+++ b/my-gpx-activities/webapp/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY ["webapp/webapp.csproj", "webapp/"]
+COPY ["my-gpx-activities.ServiceDefaults/my-gpx-activities.ServiceDefaults.csproj", "my-gpx-activities.ServiceDefaults/"]
+RUN dotnet restore "webapp/webapp.csproj"
+COPY . .
+WORKDIR "/src/webapp"
+RUN dotnet publish "webapp.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "webapp.dll"]


### PR DESCRIPTION
## Summary

Closes #32

Sets up Docker Hub image publishing for both application services.

## What's included

### Dockerfiles
- `my-gpx-activities.ApiService/Dockerfile` — multi-stage build for the API service
- `webapp/Dockerfile` — multi-stage build for the Blazor Server frontend

Both use `mcr.microsoft.com/dotnet/sdk:10.0` for build and `mcr.microsoft.com/dotnet/aspnet:10.0` for runtime, with build context set at the solution root so ServiceDefaults is available.

### GitHub Actions

**`.github/workflows/docker-publish.yml`** — Release workflow
- Triggers on `release: published`
- Extracts version from the release tag (strips `v` prefix)
- Logs in to Docker Hub using `DOCKER_USERNAME` / `DOCKER_PAT` secrets
- Pushes two images:
  - `fboucher/my-gpx-activities-api:{version}` + `latest`
  - `fboucher/my-gpx-activities-webapp:{version}` + `latest`

**`.github/workflows/docker-beta.yml`** — Beta workflow
- Triggers on push to `dev`
- Fetches all tags, finds the latest (e.g. `v0.2.0`), increments patch, appends `-beta` → `v0.2.1-beta`
- Falls back to `v0.0.1-beta` if no tags exist
- Pushes beta-tagged images only (no `latest` overwrite)

### README
Added **Docker Compose** section with a working `docker-compose.yml` example using the Docker Hub images, including health check for the DB, service discovery env var for the webapp, and instructions to swap `latest` for a pinned version.

## Secrets required
| Secret | Purpose |
|--------|---------|
| `DOCKER_USERNAME` | Docker Hub login |
| `DOCKER_PAT` | Docker Hub personal access token |