### PR TITLE
feat(#37): add devcontainer for zero-install development

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,24 @@
+# Dev Container
+
+This project includes a dev container configuration for zero-install development.
+
+## Using GitHub Codespaces
+
+Click the green **Code** button on GitHub → **Codespaces** tab → **Create codespace on dev**.
+
+## Using VS Code Dev Containers
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open this repo in VS Code
+3. Click "Reopen in Container" when prompted
+
+## After container starts
+
+The Aspire workload is installed automatically. Run the app with:
+
+```bash
+cd my-gpx-activities
+dotnet run --project my-gpx-activities.AppHost
+```
+
+Ports are forwarded automatically — check the VS Code Ports panel for URLs.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "my-gpx-activities",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": { "version": "10.0" },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "dotnet workload install aspire",
+  "forwardPorts": [15000, 15001, 15002, 15888, 15889, 15890, 8080, 8081],
+  "portsAttributes": {
+    "15888": { "label": "Aspire Dashboard", "onAutoForward": "notify" },
+    "15889": { "label": "API Service", "onAutoForward": "notify" },
+    "15890": { "label": "pgAdmin", "onAutoForward": "notify" },
+    "8080": { "label": "API (direct)", "onAutoForward": "silent" },
+    "8081": { "label": "Webapp (direct)", "onAutoForward": "silent" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.csharp",
+        "ms-azuretools.vscode-docker",
+        "GitHub.copilot",
+        "GitHub.copilot-chat"
+      ],
+      "settings": {
+        "dotnet.defaultSolution": "my-gpx-activities/my-gpx-activities.sln"
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.squad/agents/bobbie/history.md
+++ b/.squad/agents/bobbie/history.md
@@ -35,3 +35,30 @@ Key learnings:
 - Release workflow uses `docker/build-push-action@v6` and `docker/setup-buildx-action@v3` — these are the current stable major versions.
 - Images are named `fboucher/my-gpx-activities-api` and `fboucher/my-gpx-activities-webapp` (two separate repos on Docker Hub).
 - Decision documented in `.squad/decisions/inbox/bobbie-container-setup.md`.
+# History — Bobbie
+
+## Project Context
+**Project:** my-gpx-activities — GPS sports activity visualizer
+**Stack:** .NET 10 Aspire, Blazor Server (MudBlazor), ApiService (Minimal API + OpenAPI), PostgreSQL (Npgsql), NUnit tests
+**Repo layout:**
+- my-gpx-activities.ApiService/ — backend API, GPX/FIT parsing, repositories
+- my-gpx-activities.AppHost/ — Aspire orchestration host
+- my-gpx-activities.webapp/ — Blazor Server frontend
+- my-gpx-activities.ServiceDefaults/ — shared extensions
+- my-gpx-activities.Tests/ — NUnit integration tests
+**User:** fboucher
+
+## Learnings
+
+### 2026-02-25: Dev Container Setup (Issue #37)
+
+Created a dev container configuration for zero-install development in GitHub Codespaces and VS Code Dev Containers.
+
+Key learnings:
+- .NET 10 SDK requires using the base Ubuntu image with the dotnet feature (specifying `version: "10.0"`), rather than a pre-built dotnet image (which typically max out at .NET 9)
+- Docker-in-Docker is essential for Aspire applications to spin up their own services (PostgreSQL, etc.)
+- Port forwarding configuration should include both Aspire dashboard ports (15888-15890) and direct service ports (8080-8081) for flexibility
+- VS Code extensions for C# Dev Kit, Docker, and Copilot enhance the development experience significantly
+- The Aspire workload must be installed in the post-create hook to enable full orchestration capabilities
+- Adding a Codespaces badge to the README with the format `https://codespaces.new/{owner}/{repo}` provides quick access
+- Decision documented in `.squad/decisions/inbox/bobbie-devcontainer.md`

--- a/.squad/agents/holden/history.md
+++ b/.squad/agents/holden/history.md
@@ -49,3 +49,38 @@
 
 #### No blockers
 All files created cleanly on squad/readme-oss branch, PR #35 created against dev, awaiting fboucher review.
+# History — Holden
+
+## Project Context
+**Project:** my-gpx-activities — GPS sports activity visualizer
+**Stack:** .NET 10 Aspire, Blazor Server (MudBlazor), ApiService (Minimal API + OpenAPI), PostgreSQL (Npgsql), NUnit tests
+**Repo layout:**
+- my-gpx-activities.ApiService/ — backend API, GPX/FIT parsing, repositories
+- my-gpx-activities.AppHost/ — Aspire orchestration host
+- my-gpx-activities.webapp/ — Blazor Server frontend
+- my-gpx-activities.ServiceDefaults/ — shared extensions
+- my-gpx-activities.Tests/ — NUnit integration tests
+**User:** fboucher
+
+## Learnings
+
+### README Improvements (Issue #36, PR #35)
+
+**Date:** 2025-02-26  
+**Task:** Add 5 improvements to README on squad/readme-oss branch
+
+#### Improvements implemented
+1. **Screenshots placeholder:** Created `docs/screenshots/README.md` with contributor instructions; added emoji callout in README pointing to it
+2. **Prerequisites section:** New section before "Getting Started" covering .NET 10 SDK, Docker Desktop, Aspire workload installation
+3. **Tech stack badges:** Row of 5 badges (.NET 10, Blazor Server, PostgreSQL 16, Docker, MudBlazor) placed after description and before vibe-coding note
+4. **API docs note:** Added 💡 tip about Swagger UI availability after port listing
+5. **Roadmap section:** New section (before Contributing) listing 5 planned features as checkboxes
+
+#### Decisions
+- **Tech stack badge placement:** Immediately after title/existing badges for high visibility to new contributors and users
+- **Prerequisites as dedicated section:** Clearer than burying in Getting Started; makes install requirements explicit upfront
+- **Roadmap as aspirational:** Listed without owner/due date to manage expectations; allows flexible prioritization
+- **Screenshot contributor pathway:** Low-friction docs/ folder with guidance; not mandatory, encourages community participation
+
+#### No blockers
+All improvements committed to squad/readme-oss and pushed. PR #35 body updated to reference and close issue #36.

--- a/.squad/decisions/inbox/bobbie-devcontainer.md
+++ b/.squad/decisions/inbox/bobbie-devcontainer.md
@@ -1,0 +1,95 @@
+# Dev Container Setup for Zero-Install Development
+
+**Author:** Bobbie  
+**Date:** 2026-02-25  
+**Issue:** #37  
+**PR:** #38  
+**Status:** Implemented
+
+## Context
+Contributors needed to install .NET 10, Docker, and various other tools locally before contributing. The goal was to enable zero-install development using GitHub Codespaces or VS Code Dev Containers.
+
+## Decision: .NET 10 Base Image + Features
+
+**Choice:** Use `mcr.microsoft.com/devcontainers/base:ubuntu` with the dotnet feature specifying `version: "10.0"`.
+
+**Rationale:**
+- Pre-built .NET images (like `mcr.microsoft.com/devcontainers/dotnet`) typically max out at .NET 9
+- The feature-based approach allows specifying .NET 10 explicitly
+- Ubuntu base is lightweight and flexible for adding additional tools
+
+## Decision: Docker-in-Docker for Aspire
+
+**Choice:** Include the `docker-in-docker` feature.
+
+**Rationale:**
+- Aspire applications orchestrate their own services (PostgreSQL, pgAdmin, etc.) in Docker containers
+- Without Docker-in-Docker, developers cannot run the full Aspire application in the dev container
+- This feature is essential for local development parity
+
+## Decision: Port Forwarding Strategy
+
+**Ports Forwarded:**
+- Aspire Dashboard: 15888
+- API Service: 15889
+- pgAdmin: 15890
+- API (direct): 8080
+- Webapp (direct): 8081
+- Additional Aspire ports: 15000, 15001, 15002
+
+**Rationale:**
+- Aspire dashboard ports (155xx range) are used when running the AppHost
+- Direct service ports (8080, 8081) allow testing individual services or Docker Compose deployments
+- Extra ports ensure flexibility for different deployment scenarios
+
+## Decision: VS Code Extensions
+
+**Extensions Included:**
+- `ms-dotnettools.csdevkit` — C# Dev Kit for advanced IDE features
+- `ms-dotnettools.csharp` — OmniSharp for C# language support
+- `ms-azuretools.vscode-docker` — Docker integration for container management
+- `GitHub.copilot` — GitHub Copilot AI assistant
+- `GitHub.copilot-chat` — GitHub Copilot Chat for conversational AI
+
+**Rationale:**
+- C# Dev Kit provides modern .NET development experience
+- Docker extension eases container debugging and exploration
+- Copilot extensions enhance productivity and learning
+- These are commonly installed in the team's local environments
+
+## Decision: Aspire Workload Installation
+
+**Choice:** Install via `postCreateCommand: "dotnet workload install aspire"`.
+
+**Rationale:**
+- Aspire SDK workload is required to run the AppHost and its orchestration features
+- Post-create hook ensures it's installed before the developer opens the workspace
+- Takes ~2-3 minutes on first startup (acceptable trade-off for zero-install experience)
+
+## Decision: Codespaces Badge in README
+
+**Choice:** Add badge linking to `https://codespaces.new/fboucher/my-gpx-activities`.
+
+**Rationale:**
+- Makes Codespaces entry point discoverable from the README
+- Single click from browser to running dev environment in the cloud
+- Follows GitHub's standard Codespaces badge pattern
+
+## Trade-offs
+
+### Pro
+- Zero local installation required
+- Works on any machine with a browser (including Chromebooks, tablets)
+- Reproducible environment for all contributors
+- Aspire full-stack testing available immediately
+
+### Con
+- First startup takes ~5-10 minutes (workload installation + NuGet restore)
+- Codespaces has compute/storage limits on free tier
+- Not suitable for long-term development on free tier (pay model applies)
+- Bandwidth/latency depends on internet connection
+
+## Files Created
+- `.devcontainer/devcontainer.json` — Main configuration
+- `.devcontainer/README.md` — Usage instructions
+- Updated `README.md` with Codespaces badge

--- a/.squad/decisions/inbox/holden-readme-improvements.md
+++ b/.squad/decisions/inbox/holden-readme-improvements.md
@@ -1,0 +1,70 @@
+# README Improvements — Issue #36
+
+**Author:** Holden (AI Lead)  
+**Date:** 2025-02-26  
+**Issue:** #36  
+**PR:** #35  
+**Branch:** `squad/readme-oss`  
+**Status:** Committed and pushed; awaiting fboucher review
+
+## Context
+Requested 5 improvements to enhance the README's usefulness for new contributors and users.
+
+## Decision: Implementation Details
+
+### 1. Screenshots Placeholder
+- **What:** New `docs/screenshots/README.md` with contributor guidelines
+- **Why:** Lower friction for community contributions; centralizes visual documentation strategy
+- **Placement:** Referenced with 📸 emoji callout after vibe-coding note
+- **Not mandatory:** Keeps onboarding lightweight; optional enhancement
+
+### 2. Prerequisites Section
+- **What:** Dedicated section before "Getting Started" listing required tools
+- **Content:**
+  - .NET 10 SDK with download link
+  - Docker Desktop requirement (for PostgreSQL)
+  - Aspire workload installation command
+- **Why:** Makes dependencies explicit upfront; reduces install friction
+- **Alternative rejected:** Burying in Getting Started text makes requirements unclear
+
+### 3. Tech Stack Badges
+- **What:** Five shields (.NET 10, Blazor Server, PostgreSQL 16, Docker, MudBlazor)
+- **Placement:** Immediately after description, before vibe-coding note
+- **Why:** High visibility for decision-makers; signals technology maturity to potential users/contributors
+- **Choice of badges:** Match core project identity (not transient deps like NUnit)
+
+### 4. API Documentation Note
+- **What:** 💡 tip about Swagger UI at `/swagger` endpoint
+- **Placement:** After localhost port listing in "Running Locally"
+- **Why:** Developers need API contract visibility; in-app discovery better than separate docs
+- **Format:** Callout style consistent with existing Tip about Docker Compose version tags
+
+### 5. Roadmap Section
+- **What:** Five checkbox items for planned features
+- **Placement:** New section before Contributing (narrative flow: Setup → Develop → Contribute → Roadmap → License)
+- **Content:** Activity comparison, FIT support, CSV/GPX export, personal records, Strava integration
+- **Why:** Sets expectations; invites community input on priorities; not owner-assigned (flexible prioritization)
+- **No dates/owners:** Manages expectations; prevents commitment to features beyond project scope
+
+## Rationale
+
+### Section Ordering
+1. **Prerequisites** before Getting Started → install clarity first
+2. **Roadmap** before Contributing → shows vision before asking for help
+3. Both additions improve narrative flow without disrupting existing content
+
+### Badge Placement
+Placed after description to catch readers early while still highlighting the current stable status badges. Avoids banner bloat by grouping with CI/publish/Docker badges.
+
+### Optional Contributions
+Screenshots and roadmap feedback are framed as "contributions welcome" rather than requirements. Reduces friction for new contributors while inviting engagement.
+
+## Implementation Notes
+- All edits applied to `squad/readme-oss` (existing branch for PR #35)
+- New directory `docs/screenshots/` created with guidance README
+- PR #35 body updated to include "Closes #36"
+- Commit message: "docs(#36): README improvements..."
+- Single commit for clean history
+
+## No blockers
+Ready for fboucher review and merge to dev.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Docker Beta](https://github.com/fboucher/my-gpx-activities/actions/workflows/docker-beta.yml/badge.svg)](https://github.com/fboucher/my-gpx-activities/actions/workflows/docker-beta.yml)
 [![Docker Hub](https://img.shields.io/docker/pulls/fboucher/my-gpx-activities-api?label=Docker%20Hub)](https://hub.docker.com/r/fboucher/my-gpx-activities-api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/fboucher/my-gpx-activities)
 
 A .NET 10 Aspire application for managing personal GPX files. Upload, view, and analyze GPS activity data with interactive maps.
 


### PR DESCRIPTION
## Summary
Adds a `.devcontainer/` configuration so contributors can open the project in GitHub Codespaces or VS Code Dev Containers without installing .NET, Docker, or any other tooling locally.

## What's included
- `.devcontainer/devcontainer.json` — .NET 10, Docker-in-Docker, GitHub CLI
- Port forwarding for Aspire Dashboard, API, webapp, pgAdmin
- VS Code extensions pre-installed: C# Dev Kit, Docker, GitHub Copilot
- Post-create command installs the Aspire workload automatically

## Usage
Click the Codespaces badge in the README, or use VS Code Dev Containers extension.

Closes #37