### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/my-gpx-activities/Directory.Build.props
+++ b/my-gpx-activities/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.3.0</Version>
+    <Version>0.3.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Bumps version from 0.3.0 to 0.3.2 for milestone v0.3.2.

Part of milestone [v0.3.2](https://github.com/fboucher/my-gpx-activities/milestone/3).