### PR TITLE
fix: return all activities from API, remove deferred execution issue (#57)

### DIFF
--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
@@ -36,7 +36,7 @@ public class ActivityRepository : IActivityRepository
             ORDER BY start_date_time DESC
             """);
 
-        return activities.Select(MapToActivity);
+        return activities.Select(MapToActivity).ToList();
     }
 
     public async Task<Activity?> GetActivityByIdAsync(Guid id)

--- a/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
@@ -430,7 +430,7 @@ app.MapGet("/api/activities", async (IActivityRepository repository) =>
         a.MaxSpeedMs,
         TrackPoints = a.TrackPointCount,
         a.CreatedAt
-    });
+    }).ToList();
 
     return Results.Ok(response);
 })


### PR DESCRIPTION
## Summary
Fixes #57

## Root Cause
The activities API endpoint was using chained deferred LINQ execution (.Select() on top of .Select()). When ASP.NET Core serialized the IEnumerable response, if any exception occurred during enumeration, it could silently truncate the response partway through.

The chained deferred execution was:
1. Database query → IEnumerable<ActivityDto>
2. .Select(MapToActivity) → IEnumerable<Activity> (deferred)
3. .Select(anonymous projection) → IEnumerable<anonymous> (deferred)

When ASP.NET Core's JSON serializer enumerated this chain, any exception (null reference, data issue, etc.) during enumeration would stop serialization mid-stream, resulting in only partial results (11 out of 20 activities).

## Changes
- Added .ToList() to ActivityRepository.GetAllActivitiesAsync() to materialize query results immediately
- Added .ToList() to GET /api/activities endpoint response projection
- This ensures all data processing and potential errors occur within the async method's scope
- Any exceptions are now properly caught and returned as 500 errors instead of silently truncating

## Testing
- Build passes
- API Service project compiles successfully