### PR TITLE
feat: show heart rate chart for activities without GPS data (#55)

### DIFF
--- a/.squad/decisions/inbox/naomi-deferred-linq-materialization.md
+++ b/.squad/decisions/inbox/naomi-deferred-linq-materialization.md
@@ -1,0 +1,49 @@
+# Decision: Always Materialize LINQ Collections Before Returning from API Endpoints
+
+**Context:** Issue #57 revealed that chained deferred LINQ execution (.Select() on .Select()) can cause silent response truncation when exceptions occur during JSON serialization.
+
+**Problem:**
+When API endpoints return `IEnumerable<T>` with deferred LINQ operations, ASP.NET Core's JSON serializer enumerates the collection during response writing. If an exception occurs during enumeration (null reference, data corruption, serialization error), it can cause silent truncation mid-stream rather than proper error handling.
+
+**Example of problematic pattern:**
+```csharp
+// Repository
+return activities.Select(MapToActivity);  // Deferred
+
+// Endpoint
+var response = activities.Select(a => new { ... });  // Deferred on deferred
+return Results.Ok(response);  // Serializer enumerates here
+```
+
+If MapToActivity throws or serialization fails partway through, you get partial results (e.g., 11 out of 20 items).
+
+**Decision:**
+Always materialize collections with `.ToList()` or `.ToArray()` before returning from API endpoints and repositories.
+
+**Correct pattern:**
+```csharp
+// Repository
+return activities.Select(MapToActivity).ToList();  // Materialized
+
+// Endpoint
+var response = activities.Select(a => new { ... }).ToList();  // Materialized
+return Results.Ok(response);
+```
+
+**Benefits:**
+1. Exceptions occur within the async method's scope and are caught by exception handler middleware
+2. Proper 500 errors instead of silent truncation
+3. Better debuggability — full stack trace instead of mid-serialization failure
+4. More predictable behavior
+
+**Applies to:**
+- All GET endpoints returning collections
+- Repository methods returning `IEnumerable<T>`
+- Any LINQ projection that will be JSON-serialized
+
+**Related:**
+- Issue #57 (activities list truncation)
+- PR #59 (fix implementation)
+
+**Author:** Naomi (Backend Dev)
+**Date:** 2026-04-XX

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
@@ -368,12 +368,6 @@ public class ActivityRepository : IActivityRepository
         public double Max_Speed_Ms { get; set; }
         public double Max_Duration_Seconds { get; set; }
         public double Total_Elevation_Gain_Meters { get; set; }
-    
-    private class StreakWeek
-    {
-        public int First_Week { get; set; }
-        public int Last_Week { get; set; }
-        public int Streak_Length { get; set; }
     }
 
     private class StreakWeek

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
@@ -368,6 +368,12 @@ public class ActivityRepository : IActivityRepository
         public double Max_Speed_Ms { get; set; }
         public double Max_Duration_Seconds { get; set; }
         public double Total_Elevation_Gain_Meters { get; set; }
+    
+    private class StreakWeek
+    {
+        public int First_Week { get; set; }
+        public int Last_Week { get; set; }
+        public int Streak_Length { get; set; }
     }
 
     private class StreakWeek

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/Activity.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/Activity.cs
@@ -39,5 +39,9 @@ public class Activity
     // Note: older stored activities may have 5-element arrays (no cadence slot); consumers must handle both lengths.
     public string? TrackDataJson { get; set; }
 
+    public double? AverageHeartRate { get; set; }
+    public double? MaxHeartRate { get; set; }
+    public double? Calories { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/SportAverages.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/SportAverages.cs
@@ -1,0 +1,12 @@
+namespace my_gpx_activities.ApiService.Models;
+
+public record SportAverages(
+    string SportType,
+    double GlobalAvgSpeedMs,
+    double GlobalMaxSpeedMs,
+    int ActivityCount
+)
+{
+    public double GlobalAvgSpeedKmh => GlobalAvgSpeedMs * 3.6;
+    public double GlobalMaxSpeedKmh => GlobalMaxSpeedMs * 3.6;
+}

--- a/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
+++ b/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
@@ -62,18 +62,64 @@ else
         </MudItem>
     </MudGrid>
 
-    <MudCard Class="mb-4">
-        <MudCardHeader>
-            <CardHeaderContent>
-                <MudText Typo="Typo.h5">Route Map</MudText>
-            </CardHeaderContent>
-        </MudCardHeader>
-        <MudCardContent>
-            <div id="map" style="height: 400px; width: 100%; border-radius: 4px;"></div>
-        </MudCardContent>
-    </MudCard>
+    @* Map section - only show if GPS data available *@
+    @if (activity.TrackCoordinates != null && activity.TrackCoordinates.Any())
+    {
+        <MudCard Class="mb-4">
+            <MudCardHeader>
+                <CardHeaderContent>
+                    <MudText Typo="Typo.h5">Route Map</MudText>
+                </CardHeaderContent>
+            </MudCardHeader>
+            <MudCardContent>
+                <div id="map" style="height: 400px; width: 100%; border-radius: 4px;"></div>
+            </MudCardContent>
+        </MudCard>
+    }
 
-    @if (activity.TrackData != null && activity.TrackData.Any(p => p[2] != null))
+    @* Show heart rate stats for activities without GPS data *@
+    @if ((activity.TrackCoordinates == null || !activity.TrackCoordinates.Any()) && 
+         (activity.AverageHeartRate.HasValue || activity.MaxHeartRate.HasValue || activity.Calories.HasValue))
+    {
+        <MudGrid Class="mb-4">
+            @if (activity.AverageHeartRate.HasValue || activity.MaxHeartRate.HasValue)
+            {
+                <MudItem xs="12" sm="6" md="4">
+                    <MudPaper Class="pa-3 text-center" Elevation="2">
+                        <MudIcon Icon="@Icons.Material.Filled.Favorite" Size="Size.Large" Color="Color.Error" />
+                        <MudText Typo="Typo.h6" Class="mt-2">Heart Rate</MudText>
+                        @if (activity.AverageHeartRate.HasValue)
+                        {
+                            <MudText Typo="Typo.body1">Avg: @activity.AverageHeartRate.Value.ToString("F0") bpm</MudText>
+                        }
+                        @if (activity.MaxHeartRate.HasValue)
+                        {
+                            <MudText Typo="Typo.body1">Max: @activity.MaxHeartRate.Value.ToString("F0") bpm</MudText>
+                        }
+                        @if (activity.TrackData != null && activity.TrackData.Any(p => p[3] != null))
+                        {
+                            var minHR = activity.TrackData.Where(p => p[3] != null).Min(p => p[3]!.Value);
+                            <MudText Typo="Typo.body1">Min: @minHR.ToString("F0") bpm</MudText>
+                        }
+                    </MudPaper>
+                </MudItem>
+            }
+            @if (activity.Calories.HasValue)
+            {
+                <MudItem xs="12" sm="6" md="4">
+                    <MudPaper Class="pa-3 text-center" Elevation="2">
+                        <MudIcon Icon="@Icons.Material.Filled.LocalFireDepartment" Size="Size.Large" Color="Color.Warning" />
+                        <MudText Typo="Typo.h6" Class="mt-2">Calories</MudText>
+                        <MudText Typo="Typo.h4">@activity.Calories.Value.ToString("F0")</MudText>
+                    </MudPaper>
+                </MudItem>
+            }
+        </MudGrid>
+    }
+
+    @* Elevation chart - only for activities with GPS + elevation data *@
+    @if (activity.TrackCoordinates != null && activity.TrackCoordinates.Any() && 
+         activity.TrackData != null && activity.TrackData.Any(p => p[2] != null))
     {
         <MudCard Class="mb-4">
             <MudCardHeader>
@@ -89,7 +135,9 @@ else
         </MudCard>
     }
 
-    @if (activity.TrackData?.Any(p => p.Length > 4 && p[4] != null) == true)
+    @* Pace chart - only for activities with GPS + timestamps *@
+    @if (activity.TrackCoordinates != null && activity.TrackCoordinates.Any() && 
+         activity.TrackData?.Any(p => p.Length > 4 && p[4] != null) == true)
     {
         <MudCard Class="mb-4">
             <MudCardHeader>
@@ -105,6 +153,7 @@ else
         </MudCard>
     }
 
+    @* Heart rate chart - show for all activities with HR data *@
     @if (activity.TrackData != null && activity.TrackData.Any(p => p[3] != null))
     {
         <MudCard Class="mb-4">
@@ -121,7 +170,9 @@ else
         </MudCard>
     }
 
-    @if (activity.TrackData?.Any(p => p.Length > 5 && p[5] != null) == true)
+    @* Cadence chart - only for activities with GPS + cadence data *@
+    @if (activity.TrackCoordinates != null && activity.TrackCoordinates.Any() && 
+         activity.TrackData?.Any(p => p.Length > 5 && p[5] != null) == true)
     {
         <MudCard Class="mb-4">
             <MudCardHeader>
@@ -135,6 +186,15 @@ else
                 </div>
             </MudCardContent>
         </MudCard>
+    }
+
+    @* No data message - when neither GPS nor HR data available *@
+    @if ((activity.TrackCoordinates == null || !activity.TrackCoordinates.Any()) && 
+         (activity.TrackData == null || !activity.TrackData.Any(p => p[3] != null)))
+    {
+        <MudAlert Severity="Severity.Info" Class="mb-4">
+            No GPS or heart rate data available for this activity.
+        </MudAlert>
     }
 
     <MudGrid>
@@ -358,7 +418,10 @@ else
             MaxSpeedMs = storedActivity.MaxSpeedMs,
             TrackPoints = storedActivity.TrackPoints,
             TrackCoordinates = storedActivity.TrackCoordinates,
-            TrackData = storedActivity.TrackData
+            TrackData = storedActivity.TrackData,
+            AverageHeartRate = storedActivity.AverageHeartRate,
+            MaxHeartRate = storedActivity.MaxHeartRate,
+            Calories = storedActivity.Calories
         };
 
         // Load sport statistics for comparison
@@ -438,6 +501,9 @@ else
         public int TrackPoints { get; set; }
         public List<double[]>? TrackCoordinates { get; set; }
         public List<double?[]>? TrackData { get; set; }
+        public double? AverageHeartRate { get; set; }
+        public double? MaxHeartRate { get; set; }
+        public double? Calories { get; set; }
     }
 
     public async ValueTask DisposeAsync()

--- a/my-gpx-activities/webapp/Services/ActivityStore.cs
+++ b/my-gpx-activities/webapp/Services/ActivityStore.cs
@@ -67,4 +67,7 @@ public class ActivitySummary
     public DateTime CreatedAt { get; set; }
     public List<double[]>? TrackCoordinates { get; set; }
     public List<double?[]>? TrackData { get; set; }
+    public double? AverageHeartRate { get; set; }
+    public double? MaxHeartRate { get; set; }
+    public double? Calories { get; set; }
 }

--- a/my-gpx-activities/webapp/wwwroot/js/chartSync.js
+++ b/my-gpx-activities/webapp/wwwroot/js/chartSync.js
@@ -104,8 +104,8 @@ window.initActivityCharts = function(trackData, mapId) {
             const chartIdx = active[0].index;
             // Map chart index back to original trackData index
             const originalIdx = indexMap ? indexMap[chartIdx] : chartIdx;
-            // Map marker — use original trackData index
-            if (syncMarker && trackData[originalIdx]) {
+            // Map marker — use original trackData index (only for activities with GPS data)
+            if (syncMarker && trackData[originalIdx] && trackData[originalIdx][0] != null && trackData[originalIdx][1] != null) {
                 syncMarker.setLatLng([trackData[originalIdx][0], trackData[originalIdx][1]]);
             }
             // Sync crosshair on all charts
@@ -304,7 +304,8 @@ window.initActivityCharts = function(trackData, mapId) {
     });
 
     // Create sync marker on Leaflet map (the map variable is `window._leafletMap`)
-    if (window._leafletMap && trackData.length > 0) {
+    // Only for activities with GPS data (lat/lon in first two positions)
+    if (window._leafletMap && trackData.length > 0 && trackData[0][0] != null && trackData[0][1] != null) {
         syncMarker = L.circleMarker([trackData[0][0], trackData[0][1]], {
             radius: 8,
             color: '#2563eb',


### PR DESCRIPTION
## Summary
Fixes #55

Activities without GPS track data (yoga, indoor, trainer activities) now show meaningful content instead of a blank page.

## Changes
- Activity detail page detects no-GPS activities
- Shows heart rate over time chart when HR data is available
- Displays min / max / average HR stats
- Shows calories when available
- Graceful 'No data available' state when no displayable data exists

## Testing
- Build passes
- Existing tests pass