### PR TITLE
feat: add global statistics page (#3)

### DIFF
--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
@@ -273,7 +273,42 @@ public class ActivityRepository : IActivityRepository
         });
     }
 
-        private static Activity MapToActivity(ActivityDto dto)
+    
+    public async Task<GlobalStatistics> GetGlobalStatisticsAsync()
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        var streakData = await connection.QueryAsync<StreakWeek>("""
+            WITH weekly_activity AS (SELECT DISTINCT EXTRACT(YEAR FROM start_date_time)::int as year, EXTRACT(WEEK FROM start_date_time)::int as week FROM activities ORDER BY year, week),
+            week_with_row AS (SELECT year, week, year * 100 + week as year_week, ROW_NUMBER() OVER (ORDER BY year, week) as rn FROM weekly_activity),
+            streak_groups AS (SELECT year, week, year_week, year_week - rn as streak_group FROM week_with_row),
+            streaks AS (SELECT MIN(year_week) as first_week, MAX(year_week) as last_week, COUNT(*) as streak_length FROM streak_groups GROUP BY streak_group)
+            SELECT first_week, last_week, streak_length FROM streaks ORDER BY streak_length DESC, last_week DESC
+            """);
+        var streaks = streakData.ToList();
+        var longestStreak = streaks.FirstOrDefault()?.Streak_Length ?? 0;
+        var now = DateTime.UtcNow;
+        var currentYearWeek = (now.Year * 100) + (int)System.Globalization.ISOWeek.GetWeekOfYear(now);
+        var currentStreak = streaks.FirstOrDefault(s => s.Last_Week >= currentYearWeek - 1);
+        var currentWeekStreak = currentStreak?.Streak_Length ?? 0;
+        var activityDaysByWeek = await connection.QueryAsync<DayActivityCount>("""
+            SELECT EXTRACT(WEEK FROM start_date_time)::int as week_number, EXTRACT(YEAR FROM start_date_time)::int as year, COUNT(DISTINCT DATE(start_date_time)) as days_with_activities
+            FROM activities WHERE start_date_time >= NOW() - INTERVAL '12 weeks' GROUP BY year, week_number ORDER BY year DESC, week_number DESC
+            """);
+        var activityDaysByMonth = await connection.QueryAsync<MonthActivityCount>("""
+            SELECT EXTRACT(MONTH FROM start_date_time)::int as month, EXTRACT(YEAR FROM start_date_time)::int as year, COUNT(DISTINCT DATE(start_date_time)) as days_with_activities
+            FROM activities WHERE start_date_time >= NOW() - INTERVAL '12 months' GROUP BY year, month ORDER BY year DESC, month DESC
+            """);
+        var yearRecap = await connection.QueryAsync<YearSummary>("""
+            SELECT EXTRACT(YEAR FROM start_date_time)::int as year, COUNT(*)::int as total_activities, (SUM(distance_meters) / 1000.0) as total_distance_km,
+            (SUM(EXTRACT(EPOCH FROM (end_date_time - start_date_time))) / 60.0) as total_duration_minutes FROM activities GROUP BY year ORDER BY year DESC
+            """);
+        var sportCounts = await connection.QueryAsync<SportCount>("""
+            SELECT activity_type as sport_type, COUNT(*)::int as count FROM activities GROUP BY activity_type ORDER BY count DESC
+            """);
+        return new GlobalStatistics(currentWeekStreak, longestStreak, activityDaysByWeek, activityDaysByMonth, yearRecap, sportCounts);
+    }
+
+    private static Activity MapToActivity(ActivityDto dto)
     {
         return new Activity
         {
@@ -333,5 +368,12 @@ public class ActivityRepository : IActivityRepository
         public double Max_Speed_Ms { get; set; }
         public double Max_Duration_Seconds { get; set; }
         public double Total_Elevation_Gain_Meters { get; set; }
+    }
+
+    private class StreakWeek
+    {
+        public int First_Week { get; set; }
+        public int Last_Week { get; set; }
+        public int Streak_Length { get; set; }
     }
 }

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
@@ -12,6 +12,7 @@ public interface IActivityRepository
     Task<bool> DeleteActivityAsync(Guid id);
     Task<IEnumerable<SportStatistics>> GetStatisticsBySportAsync();
     Task<IEnumerable<HeatMapActivity>> GetActivitiesForHeatMapAsync(DateOnly? from, DateOnly? to, string[]? sportTypes);
+    Task<GlobalStatistics> GetGlobalStatisticsAsync();
 }
 
 public interface IActivityTypeRepository

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/GlobalStatistics.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/GlobalStatistics.cs
@@ -1,0 +1,34 @@
+namespace my_gpx_activities.ApiService.Models;
+
+public record GlobalStatistics(
+    int CurrentWeekStreak,
+    int LongestWeekStreak,
+    IEnumerable<DayActivityCount> ActivityDaysByWeek,
+    IEnumerable<MonthActivityCount> ActivityDaysByMonth,
+    IEnumerable<YearSummary> YearRecap,
+    IEnumerable<SportCount> ActivityCountBySport
+);
+
+public record DayActivityCount(
+    int WeekNumber,
+    int Year,
+    int DaysWithActivities
+);
+
+public record MonthActivityCount(
+    int Month,
+    int Year,
+    int DaysWithActivities
+);
+
+public record YearSummary(
+    int Year,
+    int TotalActivities,
+    double TotalDistanceKm,
+    double TotalDurationMinutes
+);
+
+public record SportCount(
+    string SportType,
+    int Count
+);

--- a/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
@@ -530,6 +530,14 @@ app.MapGet("/api/statistics/by-sport", async (IActivityRepository repository) =>
 .WithName("GetStatisticsBySport")
 .WithDescription("Get aggregated statistics grouped by sport type");
 
+app.MapGet("/api/statistics/global", async (IActivityRepository repository) =>
+{
+    var statistics = await repository.GetGlobalStatisticsAsync();
+    return Results.Ok(statistics);
+})
+.WithName("GetGlobalStatistics")
+.WithDescription("Get global statistics including streaks, activity days, year recap, and sport breakdown");
+
 app.MapGet("/api/activities/heatmap", async (
     IActivityRepository repository,
     DateOnly? dateFrom,

--- a/my-gpx-activities/webapp/Components/Pages/Statistics.razor
+++ b/my-gpx-activities/webapp/Components/Pages/Statistics.razor
@@ -3,10 +3,10 @@
 @inject IHttpClientFactory HttpClientFactory
 @inject ISnackbar Snackbar
 
-<PageTitle>Sport Statistics</PageTitle>
+<PageTitle>Statistics</PageTitle>
 
-<MudText Typo="Typo.h3" GutterBottom="true">Global Statistics by Sport</MudText>
-<MudText Class="mb-8">View aggregated statistics across all activities grouped by sport type.</MudText>
+<MudText Typo="Typo.h3" GutterBottom="true">Global Statistics</MudText>
+<MudText Class="mb-8">Comprehensive overview of your activity data including streaks, trends, and breakdowns.</MudText>
 
 @if (_loading)
 {
@@ -16,68 +16,115 @@ else if (_error != null)
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
 }
-else if (_statistics == null || !_statistics.Any())
+else if (_globalStats == null)
 {
     <MudAlert Severity="Severity.Info">No statistics available. Import some GPX activities first.</MudAlert>
 }
 else
 {
-    <MudGrid>
-        @foreach (var stat in _statistics)
-        {
-            <MudItem xs="12" sm="6" md="4">
-                <MudCard>
-                    <MudCardHeader>
-                        <CardHeaderContent>
-                            <MudText Typo="Typo.h5">
-                                @if (!string.IsNullOrEmpty(stat.Icon))
-                                {
-                                    <span>@stat.Icon</span>
-                                }
-                                @stat.SportName
-                            </MudText>
-                        </CardHeaderContent>
-                    </MudCardHeader>
-                    <MudCardContent>
-                        <MudText Typo="Typo.body2" Class="mb-2">
-                            <strong>Total Activities:</strong> @stat.TotalActivities
-                        </MudText>
-                        <MudText Typo="Typo.body2" Class="mb-2">
-                            <strong>Total Distance:</strong> @stat.TotalDistanceKm.ToString("F2") km
-                        </MudText>
-                        <MudText Typo="Typo.body2" Class="mb-2">
-                            <strong>Total Duration:</strong> @FormatDuration(stat.TotalDuration)
-                        </MudText>
-                        <MudText Typo="Typo.body2" Class="mb-2">
-                            <strong>Avg Speed:</strong> @stat.AverageSpeedKmh.ToString("F2") km/h
-                        </MudText>
-                        <MudText Typo="Typo.body2" Class="mb-2">
-                            <strong>Max Speed:</strong> @stat.MaxSpeedKmh.ToString("F2") km/h
-                        </MudText>
-                        <MudText Typo="Typo.body2" Class="mb-2">
-                            <strong>Max Duration:</strong> @FormatDuration(stat.MaxDuration)
-                        </MudText>
-                        <MudText Typo="Typo.body2">
-                            <strong>Total Elevation:</strong> @stat.TotalElevationGainMeters.ToString("F0") m
-                        </MudText>
-                    </MudCardContent>
-                </MudCard>
+    <MudPaper Class="pa-4 mb-4" Elevation="2">
+        <MudText Typo="Typo.h5" GutterBottom="true">Week Streaks</MudText>
+        <MudGrid>
+            <MudItem xs="12" sm="6">
+                <MudPaper Class="pa-4" Elevation="0" Style="background-color: var(--mud-palette-primary-darken);">
+                    <MudText Typo="Typo.h6" Color="Color.Primary">Current Streak</MudText>
+                    <MudText Typo="Typo.h3">@_globalStats.CurrentWeekStreak</MudText>
+                    <MudText Typo="Typo.body2">consecutive weeks</MudText>
+                </MudPaper>
             </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudPaper Class="pa-4" Elevation="0" Style="background-color: var(--mud-palette-secondary-darken);">
+                    <MudText Typo="Typo.h6" Color="Color.Secondary">Longest Streak</MudText>
+                    <MudText Typo="Typo.h3">@_globalStats.LongestWeekStreak</MudText>
+                    <MudText Typo="Typo.body2">consecutive weeks</MudText>
+                </MudPaper>
+            </MudItem>
+        </MudGrid>
+    </MudPaper>
+
+    <MudPaper Class="pa-4 mb-4" Elevation="2">
+        <MudText Typo="Typo.h5" GutterBottom="true">Activity Days by Month (Last 12 Months)</MudText>
+        @if (_globalStats.ActivityDaysByMonth.Any())
+        {
+            <MudChart ChartType="ChartType.Bar" ChartSeries="@_monthSeries" XAxisLabels="@_monthLabels" Width="100%" Height="300px" ChartOptions="@_chartOptions"/>
         }
-    </MudGrid>
+        else
+        {
+            <MudText Typo="Typo.body2">No monthly data available.</MudText>
+        }
+    </MudPaper>
+
+    <MudPaper Class="pa-4 mb-4" Elevation="2">
+        <MudText Typo="Typo.h5" GutterBottom="true">Year Recap</MudText>
+        @if (_globalStats.YearRecap.Any())
+        {
+            <MudTable Items="_globalStats.YearRecap" Hover="true" Dense="true">
+                <HeaderContent>
+                    <MudTh>Year</MudTh>
+                    <MudTh>Total Activities</MudTh>
+                    <MudTh>Total Distance (km)</MudTh>
+                    <MudTh>Total Duration (hours)</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Year">@context.Year</MudTd>
+                    <MudTd DataLabel="Total Activities">@context.TotalActivities</MudTd>
+                    <MudTd DataLabel="Total Distance">@context.TotalDistanceKm.ToString("F2")</MudTd>
+                    <MudTd DataLabel="Total Duration">@((context.TotalDurationMinutes / 60.0).ToString("F2"))</MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2">No yearly data available.</MudText>
+        }
+    </MudPaper>
+
+    <MudPaper Class="pa-4 mb-4" Elevation="2">
+        <MudText Typo="Typo.h5" GutterBottom="true">Activities by Sport Type</MudText>
+        @if (_globalStats.ActivityCountBySport.Any())
+        {
+            <MudGrid>
+                <MudItem xs="12" md="6">
+                    <MudChart ChartType="ChartType.Pie" InputData="@_sportData" InputLabels="@_sportLabels" Width="100%" Height="300px"/>
+                </MudItem>
+                <MudItem xs="12" md="6">
+                    <MudTable Items="_globalStats.ActivityCountBySport" Hover="true" Dense="true">
+                        <HeaderContent>
+                            <MudTh>Sport Type</MudTh>
+                            <MudTh>Count</MudTh>
+                        </HeaderContent>
+                        <RowTemplate>
+                            <MudTd DataLabel="Sport Type">@context.SportType</MudTd>
+                            <MudTd DataLabel="Count">@context.Count</MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </MudItem>
+            </MudGrid>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2">No sport data available.</MudText>
+        }
+    </MudPaper>
 }
 
 @code {
-    private List<SportStatisticsDto>? _statistics;
+    private GlobalStatisticsDto? _globalStats;
     private bool _loading = true;
     private string? _error;
+    private List<ChartSeries> _monthSeries = new();
+    private string[] _monthLabels = Array.Empty<string>();
+    private double[] _sportData = Array.Empty<double>();
+    private string[] _sportLabels = Array.Empty<string>();
+    private ChartOptions _chartOptions = new() { YAxisTicks = 1 };
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
             using var client = HttpClientFactory.CreateClient("ApiService");
-            _statistics = await client.GetFromJsonAsync<List<SportStatisticsDto>>("/api/statistics/by-sport");
+            _globalStats = await client.GetFromJsonAsync<GlobalStatisticsDto>("/api/statistics/global");
+            if (_globalStats != null) PrepareChartData();
         }
         catch (Exception ex)
         {
@@ -90,32 +137,65 @@ else
         }
     }
 
-    private static string FormatDuration(TimeSpan duration)
+    private void PrepareChartData()
     {
-        if (duration.TotalHours >= 1)
+        if (_globalStats == null) return;
+        var monthData = _globalStats.ActivityDaysByMonth.ToList();
+        if (monthData.Any())
         {
-            return $"{(int)duration.TotalHours:D2}:{duration.Minutes:D2}:{duration.Seconds:D2}";
+            _monthLabels = monthData.Select(m => $"{GetMonthName(m.Month)} {m.Year}").ToArray();
+            _monthSeries = new List<ChartSeries> { new ChartSeries { Name = "Days with Activities", Data = monthData.Select(m => (double)m.DaysWithActivities).ToArray() } };
         }
-        return $"{duration.Minutes:D2}:{duration.Seconds:D2}";
+        var sportData = _globalStats.ActivityCountBySport.ToList();
+        if (sportData.Any())
+        {
+            _sportLabels = sportData.Select(s => s.SportType).ToArray();
+            _sportData = sportData.Select(s => (double)s.Count).ToArray();
+        }
     }
 
-    public class SportStatisticsDto
+    private static string GetMonthName(int month) => month switch
     {
-        public string SportName { get; set; } = string.Empty;
-        public string? Icon { get; set; }
-        public string? Color { get; set; }
-        public int TotalActivities { get; set; }
-        public double TotalDistanceMeters { get; set; }
-        public double TotalDurationSeconds { get; set; }
-        public double AverageSpeedMs { get; set; }
-        public double MaxSpeedMs { get; set; }
-        public double MaxDurationSeconds { get; set; }
-        public double TotalElevationGainMeters { get; set; }
+        1 => "Jan", 2 => "Feb", 3 => "Mar", 4 => "Apr", 5 => "May", 6 => "Jun",
+        7 => "Jul", 8 => "Aug", 9 => "Sep", 10 => "Oct", 11 => "Nov", 12 => "Dec",
+        _ => month.ToString()
+    };
 
-        public double TotalDistanceKm => TotalDistanceMeters / 1000.0;
-        public double AverageSpeedKmh => AverageSpeedMs * 3.6;
-        public double MaxSpeedKmh => MaxSpeedMs * 3.6;
-        public TimeSpan TotalDuration => TimeSpan.FromSeconds(TotalDurationSeconds);
-        public TimeSpan MaxDuration => TimeSpan.FromSeconds(MaxDurationSeconds);
+    public class GlobalStatisticsDto
+    {
+        public int CurrentWeekStreak { get; set; }
+        public int LongestWeekStreak { get; set; }
+        public List<DayActivityCountDto> ActivityDaysByWeek { get; set; } = new();
+        public List<MonthActivityCountDto> ActivityDaysByMonth { get; set; } = new();
+        public List<YearSummaryDto> YearRecap { get; set; } = new();
+        public List<SportCountDto> ActivityCountBySport { get; set; } = new();
+    }
+
+    public class DayActivityCountDto
+    {
+        public int WeekNumber { get; set; }
+        public int Year { get; set; }
+        public int DaysWithActivities { get; set; }
+    }
+
+    public class MonthActivityCountDto
+    {
+        public int Month { get; set; }
+        public int Year { get; set; }
+        public int DaysWithActivities { get; set; }
+    }
+
+    public class YearSummaryDto
+    {
+        public int Year { get; set; }
+        public int TotalActivities { get; set; }
+        public double TotalDistanceKm { get; set; }
+        public double TotalDurationMinutes { get; set; }
+    }
+
+    public class SportCountDto
+    {
+        public string SportType { get; set; } = string.Empty;
+        public int Count { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
Fixes #3

Adds a full Global Statistics page with API support.

## Features
- **Week streaks**: Current and all-time longest consecutive week streaks
- **Daily activity counts**: By week (last 12 weeks) and by month (last 12 months)
- **Year recap**: Total activities, distance, and duration per year
- **Sport breakdown**: Activity count grouped by sport type

## API
- `GET /api/statistics/global` — returns all aggregated statistics

## UI  
- New `/statistics` page with MudBlazor charts and stat cards (to be added in follow-up commit)
- Navigation link added

## Testing
- Build passes
- Existing tests pass