### PR TITLE
[FEATURE] Weather conditions & personal records (issues #70, #71)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,16 @@
+# Context: my-gpx-activities
+
+## Domain Terms
+
+| Term | Definition |
+|---|---|
+| **Activity-Level Record** | The maximum value of a metric (Max Speed, Distance, Duration, Elevation Gain) among all activities of the same sport type. Records exist at two scopes: **all-time** (across all years) and **yearly** (within a calendar year). |
+| **Best Segment** | The fastest contiguous sub-segment of an activity at a standard distance (1 km, 5 km, 10 km). Computed by scanning adjacent trackpoints at import time. |
+| **Record Indicator** | A visual badge shown on the Activity Detail page when an activity sets a new record. Each sport-type/year combination that the activity breaks is shown. |
+| **Records Table** | A dedicated `activity_records` database table that materializes the current record holder for each (sport_type, year) and (sport_type, all_time) combination. Updated during import and deletion. |
+| **Best Segments Table** | A dedicated `activity_best_segments` database table storing the fastest 1 km, 5 km, and 10 km segments computed for each activity at import time. |
+| **Weather Condition** | The set of atmospheric measurements fetched for an activity: temperature (°C), condition text/icon, wind speed, wind direction, humidity, visibility. |
+| **Weather Fetch Strategy** | Weather is fetched at import time using the activity's **starting trackpoint** (first lat/lon + timestamp). If weather data is missing when viewing an activity (e.g., activities imported before this feature), it is fetched and saved on-the-fly. |
+| **Weather Data Storage** | Stored as a single `weather_data` JSONB column on the `activities` table. No separate table or normalized columns. |
+| **Weather API** | Open-Meteo Historical Weather API — free, no API key required. |
+| **Lazy Backfill** | The fallback fetch-then-cache behavior when viewing an activity that lacks weather data. |

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/ActivityRepository.cs
@@ -33,6 +33,7 @@ public class ActivityRepository : IActivityRepository
                 track_point_count,
                 track_coordinates_json,
                 track_data_json,
+                weather_data,
                 created_at
             FROM activities
             ORDER BY start_date_time DESC
@@ -60,6 +61,7 @@ public class ActivityRepository : IActivityRepository
                 track_point_count,
                 track_coordinates_json,
                 track_data_json,
+                weather_data,
                 created_at
             FROM activities
             WHERE id = @Id
@@ -87,6 +89,7 @@ public class ActivityRepository : IActivityRepository
                 track_point_count,
                 track_coordinates_json,
                 track_data_json,
+                weather_data,
                 created_at
             ) VALUES (
                 @Id,
@@ -102,6 +105,7 @@ public class ActivityRepository : IActivityRepository
                 @TrackPointCount,
                 @TrackCoordinatesJson::jsonb,
                 @TrackDataJson::jsonb,
+                @WeatherDataJson::jsonb,
                 @CreatedAt
             )
             RETURNING id
@@ -120,6 +124,7 @@ public class ActivityRepository : IActivityRepository
                 activity.TrackPointCount,
                 activity.TrackCoordinatesJson,
                 activity.TrackDataJson,
+                activity.WeatherDataJson,
                 activity.CreatedAt
             });
 
@@ -143,7 +148,8 @@ public class ActivityRepository : IActivityRepository
                 max_speed_ms = @MaxSpeedMs,
                 track_point_count = @TrackPointCount,
                 track_coordinates_json = @TrackCoordinatesJson::jsonb,
-                track_data_json = @TrackDataJson::jsonb
+                track_data_json = @TrackDataJson::jsonb,
+                weather_data = @WeatherDataJson::jsonb
             WHERE id = @Id
             """, new
             {
@@ -159,7 +165,8 @@ public class ActivityRepository : IActivityRepository
                 activity.MaxSpeedMs,
                 activity.TrackPointCount,
                 activity.TrackCoordinatesJson,
-                activity.TrackDataJson
+                activity.TrackDataJson,
+                activity.WeatherDataJson
             });
 
         return rowsAffected > 0;
@@ -208,6 +215,7 @@ public class ActivityRepository : IActivityRepository
                 track_point_count,
                 track_coordinates_json,
                 track_data_json,
+                weather_data,
                 created_at
             """, new { Id = id, Title = titleValue, ActivityType = activityTypeValue });
 
@@ -343,6 +351,148 @@ public class ActivityRepository : IActivityRepository
         return new GlobalStatistics(currentWeekStreak, longestStreak, activityDaysByWeek, activityDaysByMonth, yearRecap, sportCounts);
     }
 
+    public async Task UpdateWeatherDataAsync(Guid activityId, string? weatherDataJson)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        await connection.ExecuteAsync("""
+            UPDATE activities SET weather_data = @WeatherDataJson::jsonb WHERE id = @Id
+            """, new { Id = activityId, WeatherDataJson = weatherDataJson });
+    }
+
+    public async Task SaveBestSegmentsAsync(IEnumerable<BestSegment> segments)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        foreach (var segment in segments)
+        {
+            await connection.ExecuteAsync("""
+                INSERT INTO activity_best_segments (id, activity_id, distance_meters, speed_ms, total_time_seconds, start_track_point_index, end_track_point_index, created_at)
+                VALUES (@Id, @ActivityId, @DistanceMeters, @SpeedMs, @TotalTimeSeconds, @StartTrackPointIndex, @EndTrackPointIndex, @CreatedAt)
+                ON CONFLICT DO NOTHING
+                """, segment);
+        }
+    }
+
+    public async Task<IEnumerable<BestSegment>> GetBestSegmentsByActivityIdAsync(Guid activityId)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        return await connection.QueryAsync<BestSegment>("""
+            SELECT id, activity_id AS ActivityId, distance_meters AS DistanceMeters, speed_ms AS SpeedMs,
+                   total_time_seconds AS TotalTimeSeconds, start_track_point_index AS StartTrackPointIndex,
+                   end_track_point_index AS EndTrackPointIndex, created_at AS CreatedAt
+            FROM activity_best_segments
+            WHERE activity_id = @ActivityId
+            ORDER BY distance_meters
+            """, new { ActivityId = activityId });
+    }
+
+    public async Task<IEnumerable<ActivityRecord>> GetAllRecordsAsync(string? activityType = null)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        var sql = """
+            SELECT id, activity_id AS ActivityId, activity_type AS ActivityType, metric, value, year,
+                   achieved_at AS AchievedAt, created_at AS CreatedAt
+            FROM activity_records
+            """;
+        if (!string.IsNullOrEmpty(activityType))
+            sql += " WHERE activity_type = @ActivityType";
+        sql += " ORDER BY activity_type, metric, year NULLS LAST";
+
+        return await connection.QueryAsync<ActivityRecord>(sql, new { ActivityType = activityType });
+    }
+
+    public async Task UpsertRecordAsync(ActivityRecord record)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        await connection.ExecuteAsync("""
+            INSERT INTO activity_records (id, activity_id, activity_type, metric, value, year, achieved_at, created_at)
+            VALUES (@Id, @ActivityId, @ActivityType, @Metric, @Value, @Year, @AchievedAt, @CreatedAt)
+            ON CONFLICT (activity_type, metric, year)
+            DO UPDATE SET activity_id = @ActivityId, value = @Value, achieved_at = @AchievedAt, created_at = @CreatedAt
+            """, record);
+    }
+
+    public async Task DeleteRecordsForActivityAsync(Guid activityId)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        await connection.ExecuteAsync("DELETE FROM activity_records WHERE activity_id = @ActivityId",
+            new { ActivityId = activityId });
+    }
+
+    public async Task RecalculateRecordsAsync(string? activityType = null)
+    {
+        await using var connection = await _connectionFactory.CreateConnectionAsync();
+        var metrics = new[] { "max_speed_ms", "distance_meters", "elevation_gain_meters" };
+        var durationExpr = "EXTRACT(EPOCH FROM (end_date_time - start_date_time))";
+
+        foreach (var metric in metrics)
+        {
+            var valueCol = metric;
+            var metricName = metric switch
+            {
+                "max_speed_ms" => "MaxSpeed",
+                "distance_meters" => "Distance",
+                "elevation_gain_meters" => "ElevationGain",
+                _ => metric
+            };
+
+            var typeFilter = !string.IsNullOrEmpty(activityType) ? " AND activity_type = @ActivityType" : "";
+
+            // All-time records
+            await connection.ExecuteAsync($"""
+                INSERT INTO activity_records (id, activity_id, activity_type, metric, value, year, achieved_at, created_at)
+                SELECT gen_random_uuid(), id, activity_type, @MetricName, {valueCol}, NULL, start_date_time, NOW()
+                FROM activities
+                WHERE {valueCol} = (
+                    SELECT MAX({valueCol}) FROM activities WHERE {valueCol} > 0{typeFilter}
+                ) AND {valueCol} > 0{typeFilter}
+                LIMIT 1
+                ON CONFLICT (activity_type, metric, year)
+                DO UPDATE SET activity_id = EXCLUDED.activity_id, value = EXCLUDED.value, achieved_at = EXCLUDED.achieved_at
+                """, new { MetricName = metricName, ActivityType = activityType });
+
+            // Yearly records
+            await connection.ExecuteAsync($"""
+                INSERT INTO activity_records (id, activity_id, activity_type, metric, value, year, achieved_at, created_at)
+                SELECT DISTINCT ON (activity_type, EXTRACT(YEAR FROM start_date_time))
+                    gen_random_uuid(), id, activity_type, @MetricName, {valueCol},
+                    EXTRACT(YEAR FROM start_date_time)::int, start_date_time, NOW()
+                FROM activities
+                WHERE {valueCol} > 0{typeFilter}
+                ORDER BY activity_type, EXTRACT(YEAR FROM start_date_time), {valueCol} DESC
+                ON CONFLICT (activity_type, metric, year)
+                DO UPDATE SET activity_id = EXCLUDED.activity_id, value = EXCLUDED.value, achieved_at = EXCLUDED.achieved_at
+                """, new { MetricName = metricName, ActivityType = activityType });
+        }
+
+        // Duration records (special handling)
+        var durationMetric = "Duration";
+        var durationTypeFilter = !string.IsNullOrEmpty(activityType) ? " AND activity_type = @ActivityType2" : "";
+
+        await connection.ExecuteAsync($"""
+            INSERT INTO activity_records (id, activity_id, activity_type, metric, value, year, achieved_at, created_at)
+            SELECT gen_random_uuid(), id, activity_type, @MetricName, {durationExpr}, NULL, start_date_time, NOW()
+            FROM activities
+            WHERE {durationExpr} = (
+                SELECT MAX({durationExpr}) FROM activities WHERE {durationExpr} > 0{durationTypeFilter}
+            ) AND {durationExpr} > 0{durationTypeFilter}
+            LIMIT 1
+            ON CONFLICT (activity_type, metric, year)
+            DO UPDATE SET activity_id = EXCLUDED.activity_id, value = EXCLUDED.value, achieved_at = EXCLUDED.achieved_at
+            """, new { MetricName = durationMetric, ActivityType2 = activityType });
+
+        await connection.ExecuteAsync($"""
+            INSERT INTO activity_records (id, activity_id, activity_type, metric, value, year, achieved_at, created_at)
+            SELECT DISTINCT ON (activity_type, EXTRACT(YEAR FROM start_date_time))
+                gen_random_uuid(), id, activity_type, @MetricName, {durationExpr},
+                EXTRACT(YEAR FROM start_date_time)::int, start_date_time, NOW()
+            FROM activities
+            WHERE {durationExpr} > 0{durationTypeFilter}
+            ORDER BY activity_type, EXTRACT(YEAR FROM start_date_time), {durationExpr} DESC
+            ON CONFLICT (activity_type, metric, year)
+            DO UPDATE SET activity_id = EXCLUDED.activity_id, value = EXCLUDED.value, achieved_at = EXCLUDED.achieved_at
+            """, new { MetricName = durationMetric, ActivityType2 = activityType });
+    }
+
     private static Activity MapToActivity(ActivityDto dto)
     {
         return new Activity
@@ -360,6 +510,7 @@ public class ActivityRepository : IActivityRepository
             TrackPointCount = dto.Track_Point_Count,
             TrackCoordinatesJson = dto.Track_Coordinates_Json,
             TrackDataJson = dto.Track_Data_Json,
+            WeatherDataJson = dto.Weather_Data,
             CreatedAt = dto.Created_At
         };
     }
@@ -388,6 +539,7 @@ public class ActivityRepository : IActivityRepository
         public int Track_Point_Count { get; set; }
         public string? Track_Coordinates_Json { get; set; }
         public string? Track_Data_Json { get; set; }
+        public string? Weather_Data { get; set; }
         public DateTime Created_At { get; set; }
     }
 

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/DatabaseInitializer.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/DatabaseInitializer.cs
@@ -64,9 +64,10 @@ public class DatabaseInitializer : IDatabaseInitializer
                     );
                     """);
 
-                // Migrate existing tables: add track_data_json if missing
+                // Migrate existing tables: add track_data_json and weather_data if missing
                 await connection.ExecuteAsync("""
                     ALTER TABLE activities ADD COLUMN IF NOT EXISTS track_data_json JSONB;
+                    ALTER TABLE activities ADD COLUMN IF NOT EXISTS weather_data JSONB;
                     """);
 
                 // Create index on activities for faster queries
@@ -84,6 +85,38 @@ public class DatabaseInitializer : IDatabaseInitializer
                         message TEXT,
                         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
                     );
+                    """);
+
+                // Create activity_records table
+                await connection.ExecuteAsync("""
+                    CREATE TABLE IF NOT EXISTS activity_records (
+                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                        activity_id UUID NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+                        activity_type VARCHAR(50) NOT NULL,
+                        metric VARCHAR(50) NOT NULL,
+                        value DOUBLE PRECISION NOT NULL,
+                        year INT,
+                        achieved_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                        created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                        UNIQUE (activity_type, metric, year)
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_records_activity_type ON activity_records(activity_type);
+                    CREATE INDEX IF NOT EXISTS idx_records_activity_id ON activity_records(activity_id);
+                    """);
+
+                // Create activity_best_segments table
+                await connection.ExecuteAsync("""
+                    CREATE TABLE IF NOT EXISTS activity_best_segments (
+                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                        activity_id UUID NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
+                        distance_meters INT NOT NULL,
+                        speed_ms DOUBLE PRECISION NOT NULL,
+                        total_time_seconds DOUBLE PRECISION NOT NULL,
+                        start_track_point_index INT NOT NULL,
+                        end_track_point_index INT NOT NULL,
+                        created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_best_segments_activity_id ON activity_best_segments(activity_id);
                     """);
 
                 // Seed default activity types if none exist

--- a/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Data/IRepositories.cs
@@ -13,6 +13,19 @@ public interface IActivityRepository
     Task<IEnumerable<SportStatistics>> GetStatisticsBySportAsync();
     Task<IEnumerable<HeatMapActivity>> GetActivitiesForHeatMapAsync(DateOnly? from, DateOnly? to, string[]? sportTypes);
     Task<GlobalStatistics> GetGlobalStatisticsAsync();
+
+    // Weather
+    Task UpdateWeatherDataAsync(Guid activityId, string? weatherDataJson);
+
+    // Best segments
+    Task SaveBestSegmentsAsync(IEnumerable<BestSegment> segments);
+    Task<IEnumerable<BestSegment>> GetBestSegmentsByActivityIdAsync(Guid activityId);
+
+    // Records
+    Task<IEnumerable<ActivityRecord>> GetAllRecordsAsync(string? activityType = null);
+    Task UpsertRecordAsync(ActivityRecord record);
+    Task DeleteRecordsForActivityAsync(Guid activityId);
+    Task RecalculateRecordsAsync(string? activityType = null);
 }
 
 public interface IActivityTypeRepository

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/Activity.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/Activity.cs
@@ -43,5 +43,7 @@ public class Activity
     public double? MaxHeartRate { get; set; }
     public double? Calories { get; set; }
 
+    public string? WeatherDataJson { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/ActivityRecord.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/ActivityRecord.cs
@@ -1,0 +1,25 @@
+namespace my_gpx_activities.ApiService.Models;
+
+public class ActivityRecord
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ActivityId { get; set; }
+    public string ActivityType { get; set; } = string.Empty;
+    public string Metric { get; set; } = string.Empty;
+    public double Value { get; set; }
+    public int? Year { get; set; }
+    public DateTime AchievedAt { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public class BestSegment
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ActivityId { get; set; }
+    public int DistanceMeters { get; set; }
+    public double SpeedMs { get; set; }
+    public double TotalTimeSeconds { get; set; }
+    public int StartTrackPointIndex { get; set; }
+    public int EndTrackPointIndex { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/Strava/ImportResult.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/Strava/ImportResult.cs
@@ -1,10 +1,12 @@
 namespace my_gpx_activities.ApiService.Models.Strava;
 
-public record ImportResult
+public class ImportResult
 {
     public bool IsSuccess { get; init; }
     public Guid? ActivityId { get; init; }
     public string? Message { get; init; }
+    public List<double?[]>? TrackData { get; set; }
+    public string? ActivityType { get; set; }
 
     public static ImportResult Success(Guid activityId) => new()
     {

--- a/my-gpx-activities/my-gpx-activities.ApiService/Models/WeatherData.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Models/WeatherData.cs
@@ -1,0 +1,31 @@
+namespace my_gpx_activities.ApiService.Models;
+
+public class WeatherDataResponse
+{
+    public double TemperatureCelsius { get; set; }
+    public int WeatherCode { get; set; }
+    public string ConditionText { get; set; } = string.Empty;
+    public double WindSpeedKmh { get; set; }
+    public double WindDirectionDegrees { get; set; }
+    public double HumidityPercent { get; set; }
+    public double VisibilityKm { get; set; }
+    public string WindDirectionText { get; set; } = string.Empty;
+}
+
+public class WeatherRecord
+{
+    public required double TemperatureCelsius { get; init; }
+    public required int WeatherCode { get; init; }
+    public required string ConditionText { get; init; }
+    public required double WindSpeedKmh { get; init; }
+    public required double WindDirectionDegrees { get; init; }
+    public required double HumidityPercent { get; init; }
+    public required double VisibilityKm { get; init; }
+    public string WindDirectionText { get; set; } = string.Empty;
+}
+
+public class WeatherSettings
+{
+    public const string SectionName = "Weather";
+    public bool Enabled { get; set; } = true;
+}

--- a/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Program.cs
@@ -1,9 +1,11 @@
 using System.Text.Json;
+using Dapper;
 using my_gpx_activities.ApiService.Data;
 using my_gpx_activities.ApiService.Models;
 using my_gpx_activities.ApiService.Models.Merge;
 using my_gpx_activities.ApiService.Models.Strava;
 using my_gpx_activities.ApiService.Services;
+using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,6 +26,11 @@ builder.Services.AddScoped<IFitParserService, FitParserService>();
 builder.Services.AddScoped<ISmartMergeService, SmartMergeService>();
 builder.Services.AddScoped<IStravaImportService, StravaImportService>();
 builder.Services.AddScoped<IActivityMergeService, ActivityMergeService>();
+builder.Services.AddScoped<IBestSegmentService, BestSegmentService>();
+builder.Services.AddHttpClient<IWeatherService, OpenMeteoWeatherService>(client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(10);
+});
 builder.Services.AddProblemDetails();
 builder.Services.AddOpenApi();
 
@@ -42,6 +49,43 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
+async Task PostImportProcessing(Guid activityId, string activityType, List<double?[]> pointsData,
+    IWeatherService weatherService, IBestSegmentService bestSegmentService, IActivityRepository activityRepository,
+    ILogger logger)
+{
+    try
+    {
+        var firstPoint = pointsData.FirstOrDefault(p => p.Length > 1 && p[0].HasValue && p[1].HasValue);
+        if (firstPoint != null)
+        {
+            var ts = firstPoint.Length > 4 ? firstPoint[4] : null;
+            var timestamp = ts.HasValue
+                ? DateTimeOffset.FromUnixTimeMilliseconds((long)ts.Value).DateTime
+                : DateTime.UtcNow;
+            var weather = await weatherService.GetWeatherAsync(firstPoint[0]!.Value, firstPoint[1]!.Value, timestamp);
+            if (weather != null)
+            {
+                var weatherJson = JsonSerializer.Serialize(weather);
+                await activityRepository.UpdateWeatherDataAsync(activityId, weatherJson);
+            }
+        }
+
+        var segments = bestSegmentService.ComputeBestSegments(pointsData);
+        if (segments.Count > 0)
+        {
+            foreach (var segment in segments)
+                segment.ActivityId = activityId;
+            await activityRepository.SaveBestSegmentsAsync(segments);
+        }
+
+        await activityRepository.RecalculateRecordsAsync(activityType);
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning(ex, "Post-import processing (weather/segments/records) failed for activity {ActivityId}", activityId);
+    }
+}
+
 app.MapGet("/", () => "GPX Activities API is running. Use /api endpoints for activity management.");
 
 app.MapGet("/api/activity-types", async (IActivityTypeRepository repository) =>
@@ -51,7 +95,8 @@ app.MapGet("/api/activity-types", async (IActivityTypeRepository repository) =>
 })
 .WithName("GetActivityTypes");
 
-app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserService gpxParser, IFitParserService fitParser, IActivityRepository activityRepository) =>
+app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserService gpxParser, IFitParserService fitParser,
+    IActivityRepository activityRepository, IWeatherService weatherService, IBestSegmentService bestSegmentService) =>
 {
     try
     {
@@ -72,6 +117,7 @@ app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserServ
         }
 
         Activity? activity;
+        List<double?[]> trackData;
 
         if (isGpx)
         {
@@ -82,7 +128,7 @@ app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserServ
                 .Select(tp => new[] { tp.Latitude, tp.Longitude })
                 .ToList();
 
-            var trackData = activityData.TrackPoints
+            trackData = activityData.TrackPoints
                 .Select(tp => new double?[]
                 {
                     tp.Latitude,
@@ -113,6 +159,7 @@ app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserServ
             };
 
             await activityRepository.CreateActivityAsync(activity);
+            await PostImportProcessing(activity.Id, activity.ActivityType, trackData, weatherService, bestSegmentService, activityRepository, app.Logger);
         }
         else // FIT
         {
@@ -124,7 +171,7 @@ app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserServ
                 .Select(p => new[] { p.Latitude!.Value, p.Longitude!.Value })
                 .ToList();
 
-            var trackData = fitPoints
+            trackData = fitPoints
                 .Select(p => new double?[]
                 {
                     p.Latitude,
@@ -159,6 +206,7 @@ app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserServ
             };
 
             await activityRepository.CreateActivityAsync(activity);
+            await PostImportProcessing(activity.Id, activity.ActivityType, trackData, weatherService, bestSegmentService, activityRepository, app.Logger);
         }
 
         var response = new
@@ -187,7 +235,8 @@ app.MapPost("/api/activities/import", async (HttpRequest request, IGpxParserServ
 })
 .WithName("ImportGpxActivity");
 
-app.MapPost("/api/activities/import/batch", async (HttpRequest request, IGpxParserService gpxParser, IFitParserService fitParser, IActivityRepository activityRepository) =>
+app.MapPost("/api/activities/import/batch", async (HttpRequest request, IGpxParserService gpxParser, IFitParserService fitParser,
+    IActivityRepository activityRepository, IWeatherService weatherService, IBestSegmentService bestSegmentService) =>
 {
     try
     {
@@ -241,7 +290,8 @@ app.MapPost("/api/activities/import/batch", async (HttpRequest request, IGpxPars
                             tp.Longitude,
                             tp.Elevation,
                             tp.HeartRate,
-                            tp.Time.HasValue ? (double?)new DateTimeOffset(tp.Time.Value).ToUnixTimeMilliseconds() : null
+                            tp.Time.HasValue ? (double?)new DateTimeOffset(tp.Time.Value).ToUnixTimeMilliseconds() : null,
+                            tp.Cadence
                         })
                         .ToList();
 
@@ -308,6 +358,7 @@ app.MapPost("/api/activities/import/batch", async (HttpRequest request, IGpxPars
                 }
 
                 await activityRepository.CreateActivityAsync(activity);
+                await PostImportProcessing(activity.Id, activity.ActivityType, trackData!, weatherService, bestSegmentService, activityRepository, app.Logger);
 
                 var activityResponse = new
                 {
@@ -400,7 +451,8 @@ app.MapPost("/api/activities/smart-merge", async (HttpRequest request, ISmartMer
 .WithName("SmartMergeGpxFit")
 .WithDescription("Merge a GPX file with a FIT file, enriching trackpoints with heart-rate data matched by timestamp.");
 
-app.MapPost("/api/activities/smart-merge/import", async (HttpRequest request, ISmartMergeService smartMerge, IGpxParserService gpxParser, IActivityRepository activityRepository) =>
+app.MapPost("/api/activities/smart-merge/import", async (HttpRequest request, ISmartMergeService smartMerge, IGpxParserService gpxParser,
+    IActivityRepository activityRepository, IWeatherService weatherService, IBestSegmentService bestSegmentService) =>
 {
     try
     {
@@ -463,6 +515,7 @@ app.MapPost("/api/activities/smart-merge/import", async (HttpRequest request, IS
         };
 
         await activityRepository.CreateActivityAsync(activity);
+        await PostImportProcessing(activity.Id, activity.ActivityType, trackData, weatherService, bestSegmentService, activityRepository, app.Logger);
 
         var response = new
         {
@@ -501,12 +554,24 @@ app.MapPost("/api/activities/smart-merge/import", async (HttpRequest request, IS
 app.MapPost("/api/activities/import/strava", async (
     StravaImportRequest request,
     IStravaImportService stravaImportService,
+    IWeatherService weatherService,
+    IBestSegmentService bestSegmentService,
+    IActivityRepository activityRepository,
     Npgsql.NpgsqlDataSource dataSource) =>
 {
     try
     {
         await using var conn = await dataSource.OpenConnectionAsync();
         var result = await stravaImportService.ImportAsync(request.Activity, request.Streams, conn);
+
+        if (result.IsSuccess && result.TrackData != null && result.TrackData.Count > 0 && result.ActivityId.HasValue)
+        {
+            await PostImportProcessing(
+                result.ActivityId.Value,
+                result.ActivityType ?? "Unknown",
+                result.TrackData,
+                weatherService, bestSegmentService, activityRepository, app.Logger);
+        }
 
         if (result.IsSuccess)
         {
@@ -550,13 +615,43 @@ app.MapGet("/api/activities", async (IActivityRepository repository) =>
 })
 .WithName("GetActivities");
 
-app.MapGet("/api/activities/{id}", async (Guid id, IActivityRepository repository) =>
+app.MapGet("/api/activities/{id}", async (Guid id, IActivityRepository repository, IWeatherService weatherService) =>
 {
     var activity = await repository.GetActivityByIdAsync(id);
 
     if (activity == null)
     {
         return Results.NotFound();
+    }
+
+    // Lazy backfill weather data for activities imported before this feature
+    if (string.IsNullOrEmpty(activity.WeatherDataJson) && activity.TrackDataJson != null)
+    {
+        try
+        {
+            var backfillTrackData = JsonSerializer.Deserialize<List<double?[]>>(activity.TrackDataJson);
+            if (backfillTrackData != null)
+            {
+                var firstPoint = backfillTrackData.FirstOrDefault(p => p.Length > 1 && p[0].HasValue && p[1].HasValue);
+                if (firstPoint != null)
+                {
+                    var ts = firstPoint.Length > 4 ? firstPoint[4] : null;
+                    var timestamp = ts.HasValue
+                        ? DateTimeOffset.FromUnixTimeMilliseconds((long)ts.Value).DateTime
+                        : DateTime.UtcNow;
+                    var weather = await weatherService.GetWeatherAsync(firstPoint[0]!.Value, firstPoint[1]!.Value, timestamp);
+                    if (weather != null)
+                    {
+                        activity.WeatherDataJson = JsonSerializer.Serialize(weather);
+                        await repository.UpdateWeatherDataAsync(activity.Id, activity.WeatherDataJson);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            app.Logger.LogWarning(ex, "Weather backfill failed for activity {ActivityId}", id);
+        }
     }
 
     List<double[]>? trackCoordinates = null;
@@ -569,6 +664,12 @@ app.MapGet("/api/activities/{id}", async (Guid id, IActivityRepository repositor
     if (!string.IsNullOrEmpty(activity.TrackDataJson))
     {
         trackData = JsonSerializer.Deserialize<List<double?[]>>(activity.TrackDataJson);
+    }
+
+    WeatherRecord? weatherData = null;
+    if (!string.IsNullOrEmpty(activity.WeatherDataJson))
+    {
+        weatherData = JsonSerializer.Deserialize<WeatherRecord>(activity.WeatherDataJson);
     }
 
     var response = new
@@ -586,7 +687,8 @@ app.MapGet("/api/activities/{id}", async (Guid id, IActivityRepository repositor
         TrackPoints = activity.TrackPointCount,
         activity.CreatedAt,
         TrackCoordinates = trackCoordinates,
-        TrackData = trackData
+        TrackData = trackData,
+        Weather = weatherData
     };
 
     return Results.Ok(response);
@@ -717,6 +819,59 @@ app.MapPost("/api/activities/merge", async (MergeRequest request, IActivityMerge
 })
 .WithName("MergeActivities")
 .WithDescription("Merge two activities into a new standalone activity using append (concatenate) or merge (overlapping) mode");
+
+app.MapGet("/api/activities/{id}/weather", async (Guid id, IActivityRepository repository, IWeatherService weatherService) =>
+{
+    var activity = await repository.GetActivityByIdAsync(id);
+    if (activity == null) return Results.NotFound();
+
+    if (!string.IsNullOrEmpty(activity.WeatherDataJson))
+    {
+        var weather = JsonSerializer.Deserialize<WeatherRecord>(activity.WeatherDataJson);
+        return Results.Ok(weather);
+    }
+
+    // Lazy fetch if missing
+    if (activity.TrackDataJson != null)
+    {
+        var trackData = JsonSerializer.Deserialize<List<double?[]>>(activity.TrackDataJson);
+        var firstPoint = trackData?.FirstOrDefault(p => p is { Length: > 1 } && p[0].HasValue && p[1].HasValue);
+        if (firstPoint != null)
+        {
+            var ts = firstPoint.Length > 4 ? firstPoint[4] : null;
+            var timestamp = ts.HasValue
+                ? DateTimeOffset.FromUnixTimeMilliseconds((long)ts.Value).DateTime
+                : DateTime.UtcNow;
+            var weather = await weatherService.GetWeatherAsync(firstPoint[0]!.Value, firstPoint[1]!.Value, timestamp);
+            if (weather != null)
+            {
+                var weatherJson = JsonSerializer.Serialize(weather);
+                await repository.UpdateWeatherDataAsync(activity.Id, weatherJson);
+                return Results.Ok(weather);
+            }
+        }
+    }
+
+    return Results.Ok((object?)null);
+})
+.WithName("GetActivityWeather")
+.WithDescription("Get weather data for an activity, with lazy backfill if not yet fetched");
+
+app.MapGet("/api/activities/{id}/best-segments", async (Guid id, IActivityRepository repository) =>
+{
+    var segments = await repository.GetBestSegmentsByActivityIdAsync(id);
+    return Results.Ok(segments);
+})
+.WithName("GetActivityBestSegments")
+.WithDescription("Get best segments (fastest 1/5/10 km) for an activity");
+
+app.MapGet("/api/records", async (string? activityType, IActivityRepository repository) =>
+{
+    var records = await repository.GetAllRecordsAsync(activityType);
+    return Results.Ok(records);
+})
+.WithName("GetRecords")
+.WithDescription("Get personal records, optionally filtered by activity type");
 
 app.MapDefaultEndpoints();
 

--- a/my-gpx-activities/my-gpx-activities.ApiService/Services/BestSegmentService.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Services/BestSegmentService.cs
@@ -1,0 +1,100 @@
+using my_gpx_activities.ApiService.Models;
+
+namespace my_gpx_activities.ApiService.Services;
+
+public interface IBestSegmentService
+{
+    List<BestSegment> ComputeBestSegments(List<double?[]> trackData);
+}
+
+public class BestSegmentService : IBestSegmentService
+{
+    private static readonly int[] SegmentDistances = [1000, 5000, 10000];
+
+    private static double CalculateDistance(double lat1, double lon1, double lat2, double lon2)
+    {
+        const double R = 6371000;
+        var dLat = ToRadians(lat2 - lat1);
+        var dLon = ToRadians(lon2 - lon1);
+        var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+                Math.Cos(ToRadians(lat1)) * Math.Cos(ToRadians(lat2)) *
+                Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+        var c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+        return R * c;
+    }
+
+    private static double ToRadians(double degrees) => degrees * Math.PI / 180;
+
+    public List<BestSegment> ComputeBestSegments(List<double?[]> trackData)
+    {
+        if (trackData.Count < 2) return [];
+
+        // Build cumulative distance and time arrays
+        var points = trackData
+            .Select(p => new
+            {
+                Lat = p.Length > 0 ? p[0] : null,
+                Lon = p.Length > 1 ? p[1] : null,
+                Time = p.Length > 4 ? p[4] : null
+            })
+            .ToList();
+
+        // Filter to points with GPS data
+        var gpsPoints = points.Where(p => p.Lat.HasValue && p.Lon.HasValue).ToList();
+        if (gpsPoints.Count < 2) return [];
+
+        var cumulativeDistances = new double[gpsPoints.Count];
+        cumulativeDistances[0] = 0;
+        for (int i = 1; i < gpsPoints.Count; i++)
+        {
+            var prev = gpsPoints[i - 1];
+            var curr = gpsPoints[i];
+            cumulativeDistances[i] = cumulativeDistances[i - 1] +
+                CalculateDistance(prev.Lat!.Value, prev.Lon!.Value, curr.Lat!.Value, curr.Lon!.Value);
+        }
+
+        var results = new List<BestSegment>();
+        foreach (var targetDistance in SegmentDistances)
+        {
+            BestSegment? best = null;
+            for (int start = 0; start < gpsPoints.Count; start++)
+            {
+                var end = start;
+                while (end < gpsPoints.Count && cumulativeDistances[end] - cumulativeDistances[start] < targetDistance)
+                    end++;
+
+                if (end >= gpsPoints.Count) break;
+
+                var segmentDistance = cumulativeDistances[end] - cumulativeDistances[start];
+
+                double? startTime = gpsPoints[start].Time;
+                double? endTime = gpsPoints[end].Time;
+                if (!startTime.HasValue || !endTime.HasValue) continue;
+
+                var timeSeconds = (endTime.Value - startTime.Value) / 1000.0;
+                if (timeSeconds <= 0) continue;
+
+                var speed = segmentDistance / timeSeconds;
+
+                if (best == null || speed > best.SpeedMs)
+                {
+                    best = new BestSegment
+                    {
+                        Id = Guid.NewGuid(),
+                        DistanceMeters = targetDistance,
+                        SpeedMs = speed,
+                        TotalTimeSeconds = timeSeconds,
+                        StartTrackPointIndex = start,
+                        EndTrackPointIndex = end,
+                        CreatedAt = DateTime.UtcNow
+                    };
+                }
+            }
+
+            if (best != null)
+                results.Add(best);
+        }
+
+        return results;
+    }
+}

--- a/my-gpx-activities/my-gpx-activities.ApiService/Services/StravaImportService.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Services/StravaImportService.cs
@@ -113,7 +113,10 @@ public class StravaImportService : IStravaImportService
             });
 
             _logger.LogInformation("Successfully imported Strava activity {StravaId} as {ActivityId}", stravaId, activityId);
-            return ImportResult.Success(activityId);
+            var result = ImportResult.Success(activityId);
+            result.TrackData = trackData;
+            result.ActivityType = activityType;
+            return result;
         }
         catch (Exception ex)
         {

--- a/my-gpx-activities/my-gpx-activities.ApiService/Services/WeatherService.cs
+++ b/my-gpx-activities/my-gpx-activities.ApiService/Services/WeatherService.cs
@@ -1,0 +1,139 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using my_gpx_activities.ApiService.Models;
+
+namespace my_gpx_activities.ApiService.Services;
+
+public interface IWeatherService
+{
+    Task<WeatherRecord?> GetWeatherAsync(double latitude, double longitude, DateTime timestamp, CancellationToken cancellationToken = default);
+}
+
+public class OpenMeteoWeatherService(HttpClient httpClient) : IWeatherService
+{
+    private static readonly Dictionary<int, string> WeatherCodes = new()
+    {
+        [0] = "Clear sky",
+        [1] = "Mainly clear",
+        [2] = "Partly cloudy",
+        [3] = "Overcast",
+        [45] = "Foggy",
+        [48] = "Depositing rime fog",
+        [51] = "Light drizzle",
+        [53] = "Moderate drizzle",
+        [55] = "Dense drizzle",
+        [56] = "Light freezing drizzle",
+        [57] = "Dense freezing drizzle",
+        [61] = "Slight rain",
+        [63] = "Moderate rain",
+        [65] = "Heavy rain",
+        [66] = "Light freezing rain",
+        [67] = "Heavy freezing rain",
+        [71] = "Slight snow",
+        [73] = "Moderate snow",
+        [75] = "Heavy snow",
+        [77] = "Snow grains",
+        [80] = "Slight rain showers",
+        [81] = "Moderate rain showers",
+        [82] = "Violent rain showers",
+        [85] = "Slight snow showers",
+        [86] = "Heavy snow showers",
+        [95] = "Thunderstorm",
+        [96] = "Thunderstorm with slight hail",
+        [99] = "Thunderstorm with heavy hail",
+    };
+
+    private static string WindDirectionText(double degrees) => degrees switch
+    {
+        >= 337.5 or < 22.5 => "N",
+        >= 22.5 and < 67.5 => "NE",
+        >= 67.5 and < 112.5 => "E",
+        >= 112.5 and < 157.5 => "SE",
+        >= 157.5 and < 202.5 => "S",
+        >= 202.5 and < 247.5 => "SW",
+        >= 247.5 and < 292.5 => "W",
+        _ => "NW",
+    };
+
+    public async Task<WeatherRecord?> GetWeatherAsync(double latitude, double longitude, DateTime timestamp, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var date = timestamp.ToString("yyyy-MM-dd");
+            var url = $"https://archive-api.open-meteo.com/v1/archive?" +
+                      $"latitude={latitude:F4}&longitude={longitude:F4}" +
+                      $"&start_date={date}&end_date={date}" +
+                      $"&hourly=temperature_2m,relative_humidity_2m,wind_speed_10m,wind_direction_10m,weather_code,visibility" +
+                      $"&timezone=auto";
+
+            var response = await httpClient.GetFromJsonAsync<OpenMeteoResponse>(url, cancellationToken);
+            if (response?.Hourly == null) return null;
+
+            var hour = timestamp.Hour;
+            var times = response.Hourly.Time;
+            var index = -1;
+            for (int i = 0; i < (times?.Length ?? 0); i++)
+            {
+                DateTime parsed;
+                if (DateTime.TryParse(times![i], out parsed) && parsed.Hour == hour)
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index < 0 || index >= (response.Hourly.Temperature2M?.Length ?? 0))
+                return null;
+
+            var weatherCode = (int)(response.Hourly.WeatherCode?[index] ?? 0);
+            var conditionText = WeatherCodes.GetValueOrDefault(weatherCode, "Unknown");
+            var windDegrees = response.Hourly.WindDirection10M?[index] ?? 0;
+
+            return new WeatherRecord
+            {
+                TemperatureCelsius = response.Hourly.Temperature2M?[index] ?? 0,
+                WeatherCode = weatherCode,
+                ConditionText = conditionText,
+                WindSpeedKmh = response.Hourly.WindSpeed10M?[index] ?? 0,
+                WindDirectionDegrees = windDegrees,
+                WindDirectionText = WindDirectionText(windDegrees),
+                HumidityPercent = response.Hourly.RelativeHumidity2M?[index] ?? 0,
+                VisibilityKm = (response.Hourly.Visibility?[index] ?? 0) / 1000.0,
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private class OpenMeteoResponse
+    {
+        [JsonPropertyName("hourly")]
+        public OpenMeteoHourly? Hourly { get; set; }
+    }
+
+    private class OpenMeteoHourly
+    {
+        [JsonPropertyName("time")]
+        public string[]? Time { get; set; }
+
+        [JsonPropertyName("temperature_2m")]
+        public double[]? Temperature2M { get; set; }
+
+        [JsonPropertyName("relative_humidity_2m")]
+        public double[]? RelativeHumidity2M { get; set; }
+
+        [JsonPropertyName("wind_speed_10m")]
+        public double[]? WindSpeed10M { get; set; }
+
+        [JsonPropertyName("wind_direction_10m")]
+        public double[]? WindDirection10M { get; set; }
+
+        [JsonPropertyName("weather_code")]
+        public double[]? WeatherCode { get; set; }
+
+        [JsonPropertyName("visibility")]
+        public double[]? Visibility { get; set; }
+    }
+}

--- a/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
+++ b/my-gpx-activities/webapp/Components/Pages/ActivityDetail.razor
@@ -28,6 +28,18 @@ else
                        OnClick="OpenEditDialog" />
     </MudStack>
 
+    @if (_newRecords != null && _newRecords.Count > 0)
+    {
+        <MudStack Row="true" Spacing="1" Class="mb-2">
+            @foreach (var record in _newRecords)
+            {
+                <MudChip T="string" Color="Color.Warning" Size="Size.Small" Icon="@Icons.Material.Filled.EmojiEvents">
+                    New @FormatMetricName(record.Metric) @(record.Year.HasValue ? record.Year.Value.ToString() : "All-Time")
+                </MudChip>
+            }
+        </MudStack>
+    }
+
     <MudGrid Class="mb-4">
         <MudItem xs="12" sm="6" md="3">
             <MudPaper Class="pa-3 text-center" Elevation="2">
@@ -60,6 +72,21 @@ else
                 <MudText Typo="Typo.h4">@FormatSpeed(activity.AverageSpeedMs)</MudText>
             </MudPaper>
         </MudItem>
+
+        @if (activity.Weather != null)
+        {
+            <MudItem xs="12" sm="6" md="3">
+                <MudPaper Class="pa-3 text-center" Elevation="2">
+                    <MudIcon Icon="@Icons.Material.Filled.Cloud" Size="Size.Large" Color="Color.Default" />
+                    <MudText Typo="Typo.h6" Class="mt-2">Weather</MudText>
+                    <MudText Typo="Typo.body2">@activity.Weather.ConditionText</MudText>
+                    <MudText Typo="Typo.body1">@activity.Weather.TemperatureCelsius.ToString("F0")°C</MudText>
+                    <MudText Typo="Typo.body2">@activity.Weather.WindSpeedKmh.ToString("F0") km/h @activity.Weather.WindDirectionText</MudText>
+                    <MudText Typo="Typo.body2">Humidity: @activity.Weather.HumidityPercent.ToString("F0")%</MudText>
+                    <MudText Typo="Typo.body2">Visibility: @activity.Weather.VisibilityKm.ToString("F1") km</MudText>
+                </MudPaper>
+            </MudItem>
+        }
     </MudGrid>
 
     @* Map section - only show if GPS data available *@
@@ -238,6 +265,42 @@ else
             </MudCard>
         </MudItem>
 
+        @if (_bestSegments.Count > 0)
+        {
+            <MudItem xs="12" md="6">
+                <MudCard>
+                    <MudCardHeader>
+                        <CardHeaderContent>
+                            <MudText Typo="Typo.h6">Best Segments</MudText>
+                        </CardHeaderContent>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudSimpleTable Dense="true" Hover="true">
+                            <thead>
+                                <tr>
+                                    <th>Distance</th>
+                                    <th>Time</th>
+                                    <th>Speed</th>
+                                    <th>Pace</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var seg in _bestSegments)
+                                {
+                                    <tr>
+                                        <td>@FormatSegmentDistance(seg.DistanceMeters)</td>
+                                        <td>@FormatSegmentDuration(seg.TotalTimeSeconds)</td>
+                                        <td>@FormatSpeed(seg.SpeedMs)</td>
+                                        <td>@FormatPace(seg.SpeedMs)</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    </MudCardContent>
+                </MudCard>
+            </MudItem>
+        }
+
         <MudItem xs="12" md="6">
             <MudCard>
                 <MudCardHeader>
@@ -304,6 +367,8 @@ else
     private webapp.Services.ActivityApiClient.SportStatisticsDto? sportStats;
     private bool _initialized = false;
     private Guid _loadedId;
+    private List<BestSegmentDto> _bestSegments = new();
+    private List<ActivityRecordDto> _newRecords = new();
 
     private async Task OpenEditDialog()
     {
@@ -436,11 +501,74 @@ else
             TrackData = storedActivity.TrackData,
             AverageHeartRate = storedActivity.AverageHeartRate,
             MaxHeartRate = storedActivity.MaxHeartRate,
-            Calories = storedActivity.Calories
+            Calories = storedActivity.Calories,
+            Weather = storedActivity.Weather
         };
 
         // Load sport statistics for comparison
         await LoadSportStatisticsAsync();
+
+        // Load best segments
+        try
+        {
+            _bestSegments = (await ActivityApiClient.GetBestSegmentsAsync(activity.Id))
+                .OrderBy(s => s.DistanceMeters)
+                .Where(s => s.SpeedMs > 0)
+                .ToList();
+        }
+        catch
+        {
+            // Best segments not available (e.g., no GPS data)
+        }
+
+        // Detect new records by comparing with current records
+        try
+        {
+            var allRecords = await ActivityApiClient.GetRecordsAsync(activity.ActivityType);
+            var relevantMetrics = _newRecordCandidates.Select(m => m.Key).ToList();
+            _newRecords = allRecords
+                .Where(r => r.ActivityId == activity.Id.ToString() && relevantMetrics.Contains(r.Metric))
+                .ToList();
+        }
+        catch
+        {
+            // Records not available
+        }
+    }
+
+    private static readonly Dictionary<string, string> _newRecordCandidates = new()
+    {
+        ["MaxSpeed"] = "Max Speed",
+        ["Distance"] = "Distance",
+        ["Duration"] = "Duration",
+        ["ElevationGain"] = "Elevation Gain"
+    };
+
+    private string FormatMetricName(string metricKey)
+    {
+        return _newRecordCandidates.TryGetValue(metricKey, out var name) ? name : metricKey;
+    }
+
+    private string FormatSegmentDistance(int meters)
+    {
+        if (meters >= 1000)
+            return $"{meters / 1000} km";
+        return $"{meters} m";
+    }
+
+    private string FormatSegmentDuration(double seconds)
+    {
+        var ts = TimeSpan.FromSeconds(seconds);
+        return $"{(int)ts.TotalMinutes}:{ts.Seconds:D2}";
+    }
+
+    private string FormatPace(double speedMs)
+    {
+        if (speedMs <= 0) return "-";
+        var paceMinPerKm = 1000.0 / (speedMs * 60.0);
+        var minutes = (int)paceMinPerKm;
+        var seconds = (int)((paceMinPerKm - minutes) * 60);
+        return $"{minutes}:{seconds:D2} /km";
     }
 
     private async Task InitializeMap()
@@ -519,6 +647,7 @@ else
         public double? AverageHeartRate { get; set; }
         public double? MaxHeartRate { get; set; }
         public double? Calories { get; set; }
+        public WeatherRecordDto? Weather { get; set; }
     }
 
     public async ValueTask DisposeAsync()

--- a/my-gpx-activities/webapp/Components/Pages/Statistics.razor
+++ b/my-gpx-activities/webapp/Components/Pages/Statistics.razor
@@ -2,6 +2,7 @@
 @using System.Net.Http.Json
 @inject IHttpClientFactory HttpClientFactory
 @inject ISnackbar Snackbar
+@inject webapp.Services.ActivityApiClient ActivityApiClient
 
 <PageTitle>Statistics</PageTitle>
 
@@ -106,6 +107,33 @@ else
             <MudText Typo="Typo.body2">No sport data available.</MudText>
         }
     </MudPaper>
+
+    <MudPaper Class="pa-4 mb-4" Elevation="2">
+        <MudText Typo="Typo.h5" GutterBottom="true">Personal Records</MudText>
+        @if (_records != null && _records.Any())
+        {
+            <MudTable Items="@_records" Hover="true" Dense="true">
+                <HeaderContent>
+                    <MudTh>Sport</MudTh>
+                    <MudTh>Metric</MudTh>
+                    <MudTh>Value</MudTh>
+                    <MudTh>Scope</MudTh>
+                    <MudTh>Achieved</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Sport">@context.ActivityType</MudTd>
+                    <MudTd DataLabel="Metric">@FormatRecordMetric(context.Metric)</MudTd>
+                    <MudTd DataLabel="Value">@FormatRecordValue(context.Metric, context.Value)</MudTd>
+                    <MudTd DataLabel="Scope">@(context.Year.HasValue ? context.Year.ToString() : "All-Time")</MudTd>
+                    <MudTd DataLabel="Achieved">@context.AchievedAt.ToString("MMM dd, yyyy")</MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+        else
+        {
+            <MudText Typo="Typo.body2">No records yet. Import some activities to start tracking.</MudText>
+        }
+    </MudPaper>
 }
 
 @code {
@@ -117,6 +145,7 @@ else
     private double[] _sportData = Array.Empty<double>();
     private string[] _sportLabels = Array.Empty<string>();
     private ChartOptions _chartOptions = new() { YAxisTicks = 1 };
+    private List<ActivityRecordDto> _records = new();
 
     protected override async Task OnInitializedAsync()
     {
@@ -125,6 +154,8 @@ else
             using var client = HttpClientFactory.CreateClient("ApiService");
             _globalStats = await client.GetFromJsonAsync<GlobalStatisticsDto>("/api/statistics/global");
             if (_globalStats != null) PrepareChartData();
+
+            _records = await ActivityApiClient.GetRecordsAsync();
         }
         catch (Exception ex)
         {
@@ -136,6 +167,24 @@ else
             _loading = false;
         }
     }
+
+    private string FormatRecordMetric(string metric) => metric switch
+    {
+        "MaxSpeed" => "Max Speed",
+        "Distance" => "Distance",
+        "Duration" => "Duration",
+        "ElevationGain" => "Elevation Gain",
+        _ => metric
+    };
+
+    private string FormatRecordValue(string metric, double value) => metric switch
+    {
+        "MaxSpeed" => $"{value * 3.6:F1} km/h",
+        "Distance" => $"{(value >= 1000 ? $"{value / 1000:F2} km" : $"{value:F0} m")}",
+        "Duration" => $"{TimeSpan.FromSeconds(value):hh\\:mm\\:ss}",
+        "ElevationGain" => $"{value:F0} m",
+        _ => value.ToString("F2")
+    };
 
     private void PrepareChartData()
     {

--- a/my-gpx-activities/webapp/Services/ActivityApiClient.cs
+++ b/my-gpx-activities/webapp/Services/ActivityApiClient.cs
@@ -100,4 +100,19 @@ public class ActivityApiClient(IHttpClientFactory httpClientFactory)
         var result = await _client.GetFromJsonAsync<List<SportStatisticsDto>>("/api/statistics/by-sport", cancellationToken);
         return result ?? [];
     }
+
+    public async Task<List<BestSegmentDto>> GetBestSegmentsAsync(Guid activityId, CancellationToken cancellationToken = default)
+    {
+        var result = await _client.GetFromJsonAsync<List<BestSegmentDto>>($"/api/activities/{activityId}/best-segments", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<List<ActivityRecordDto>> GetRecordsAsync(string? activityType = null, CancellationToken cancellationToken = default)
+    {
+        var url = "/api/records";
+        if (!string.IsNullOrEmpty(activityType))
+            url += $"?activityType={Uri.EscapeDataString(activityType)}";
+        var result = await _client.GetFromJsonAsync<List<ActivityRecordDto>>(url, cancellationToken);
+        return result ?? [];
+    }
 }

--- a/my-gpx-activities/webapp/Services/ActivityStore.cs
+++ b/my-gpx-activities/webapp/Services/ActivityStore.cs
@@ -70,4 +70,39 @@ public class ActivitySummary
     public double? AverageHeartRate { get; set; }
     public double? MaxHeartRate { get; set; }
     public double? Calories { get; set; }
+    public WeatherRecordDto? Weather { get; set; }
+}
+
+public class WeatherRecordDto
+{
+    public double TemperatureCelsius { get; set; }
+    public int WeatherCode { get; set; }
+    public string ConditionText { get; set; } = string.Empty;
+    public double WindSpeedKmh { get; set; }
+    public double WindDirectionDegrees { get; set; }
+    public double HumidityPercent { get; set; }
+    public double VisibilityKm { get; set; }
+    public string WindDirectionText { get; set; } = string.Empty;
+}
+
+public class BestSegmentDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string ActivityId { get; set; } = string.Empty;
+    public int DistanceMeters { get; set; }
+    public double SpeedMs { get; set; }
+    public double TotalTimeSeconds { get; set; }
+    public int StartTrackPointIndex { get; set; }
+    public int EndTrackPointIndex { get; set; }
+}
+
+public class ActivityRecordDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string ActivityId { get; set; } = string.Empty;
+    public string ActivityType { get; set; } = string.Empty;
+    public string Metric { get; set; } = string.Empty;
+    public double Value { get; set; }
+    public int? Year { get; set; }
+    public DateTime AchievedAt { get; set; }
 }


### PR DESCRIPTION
## Summary

This PR implements two features:

### Issue #71 — Weather Conditions
- Fetches weather data from Open-Meteo API (free, no key) at import time
- Weather is queried using the activity's first trackpoint (lat/lon + timestamp)
- Fields: temperature, condition text, wind speed/direction, humidity, visibility
- Stored as `weather_data` JSONB column on the `activities` table
- Lazy backfill: weather is fetched on-demand if missing when viewing an activity
- Weather card displayed on Activity Detail page

### Issue #70 — Personal Records & Best Segments
- Materialized `activity_records` table tracks best values per (sport_type, metric, year)
- Metrics tracked: Max Speed, Distance, Duration, Elevation Gain
- Records scope: yearly + all-time per sport type
- New record indicators (badges) shown on Activity Detail page when an activity breaks a record
- `activity_best_segments` table stores fastest contiguous 1 km, 5 km, 10 km segments
- Best segments computed at import time from GPS trackpoint data
- Records table displayed on Statistics page
- New API endpoints: `GET /api/records`, `GET /api/activities/{id}/best-segments`, `GET /api/activities/{id}/weather`

### Files Changed
- **ApiService**: New services (WeatherService, BestSegmentService), new models (WeatherData, ActivityRecord, BestSegment), updated repository, schema migration, wired imports, new endpoints
- **Webapp**: Weather card + record badges + best segments on ActivityDetail.razor, records table on Statistics.razor, updated API client and store
- **Database**: Add `weather_data` JSONB column, create `activity_records` and `activity_best_segments` tables

### Notes
- Best segments currently skip FIT imports (no distance data) and Strava polyline-only imports (no timestamps)
- Weather API calls are best-effort and silently fail if the API is unavailable
- Open-Meteo is used (free, no API key) — see `CONTEXT.md` for domain glossary